### PR TITLE
Tune Apache + PHP + MW cache defaults for single-VPS deployments

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,6 +16,15 @@ RUN apt-get update && apt-get install -y \
     git unzip ca-certificates mariadb-client curl \
     && rm -rf /var/lib/apt/lists/*
 
+# Apache + PHP tuning for long-lived MediaWiki deployments.
+# MaxConnectionsPerChild bounds Apache worker lifetime so in-process PHP
+# state (SMW's in-memory caches in particular) can't accumulate stale
+# entries indefinitely. Opcache + APCu settings give a sensible baseline
+# for a single-VPS install serving up to ~1000 users/day.
+COPY docker/apache/labki-tuning.conf /etc/apache2/conf-available/labki-tuning.conf
+COPY docker/php/labki-tuning.ini /usr/local/etc/php/conf.d/zz-labki-tuning.ini
+RUN a2enconf labki-tuning
+
 # Install Composer
 COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
 

--- a/docker/apache/labki-tuning.conf
+++ b/docker/apache/labki-tuning.conf
@@ -1,0 +1,12 @@
+# Labki Platform — Apache tuning
+#
+# Recycle each Apache worker process after a finite number of requests so
+# long-lived in-process PHP state can't accumulate indefinitely. Without
+# this, mod_php workers serve requests for the life of the container
+# (days to weeks), and any PHP-level cache that lacks a real TTL (e.g.
+# SMW's in-memory CompositeCache layer) holds stale entries forever.
+#
+# 1000 is a compromise: high enough that worker churn is negligible for
+# throughput, low enough that any transient poisoned cache entry is
+# flushed within a few minutes of traffic.
+MaxConnectionsPerChild 1000

--- a/docker/php/labki-tuning.ini
+++ b/docker/php/labki-tuning.ini
@@ -1,0 +1,19 @@
+; Labki Platform — PHP tuning
+;
+; Opcache: compile PHP once per interpreter, serve bytecode from shared
+; memory on every request. This is by far the largest single PHP perf
+; win; values are sized for a MW+SMW workload on a 1–2 GB VPS.
+opcache.enable=1
+opcache.memory_consumption=256
+opcache.interned_strings_buffer=32
+opcache.max_accelerated_files=20000
+opcache.revalidate_freq=60
+opcache.validate_timestamps=1
+
+; APCu: user-data cache backing MediaWiki's CACHE_ACCEL and SMW's
+; in-memory lookups. `enable_cli=1` matters for maintenance scripts
+; (runJobs, rebuildData) — without it, CLI invocations silently bypass
+; the cache layer and can write semantics that web workers then miss.
+apc.enabled=1
+apc.enable_cli=1
+apc.shm_size=256M

--- a/mediawiki/LocalSettings.defaults.php
+++ b/mediawiki/LocalSettings.defaults.php
@@ -22,8 +22,30 @@ $wgDebugLogFile = "php://stderr";
 ini_set('display_errors', 0);
 $wgShowExceptionDetails = false;
 
-// Job Queue - defer to background runner (avoids UI lag)
+// Job Queue - defer to background runner (avoids UI lag).
+// The labki deployment repo ships a `wiki-jobrunner` container that
+// drains the queue continuously; user-facing requests do not run jobs.
+// If you disable that container, restore $wgJobRunRate = 1 in your
+// user config so saves still process eventually (at the cost of
+// slower UX).
 $wgJobRunRate = 0;
+
+// Cache routing.
+//
+// $wgMainCacheType is set in LocalSettings.base.php to CACHE_ACCEL
+// (APCu). Route session and message caches to the same fast in-process
+// store. ParserCache entries can be multi-MB and benefit from
+// durability across worker restarts, so keep it on the database.
+$wgSessionCacheType = CACHE_ACCEL;
+$wgMessageCacheType = CACHE_ACCEL;
+$wgParserCacheType  = CACHE_DB;
+
+// SMW caches default to CACHE_ANYTHING which resolves through
+// $wgMainCacheType anyway, but making it explicit is helpful for ops
+// and protects against surprises if a user overrides $wgMainCacheType
+// to something SMW's CompositeCache can't use.
+$smwgMainCacheType = CACHE_ACCEL;
+$smwgQueryResultCacheType = CACHE_ACCEL;
 
 // Footer Badge - Powered by Labki
 $wgFooterIcons['poweredby']['labki'] = [


### PR DESCRIPTION
## Summary

Bakes sensible Apache, PHP, and MediaWiki cache defaults into the platform image for Labki installs serving up to ~1000 users/day on a single host. Everything is scoped to the image so existing deployments just need to pull a new version.

## Changes

### Apache — recycle workers

`docker/apache/labki-tuning.conf` (new) + Dockerfile `COPY` + `a2enconf`:

```apache
MaxConnectionsPerChild 1000
```

Apache mod_php prefork defaults to `MaxConnectionsPerChild 0` — workers live for the lifetime of the container (days to weeks). Every PHP interpreter-level cache that lacks a real TTL keeps state for that entire lifetime. This directly caused [labki-org/SemanticSchemas#156](https://github.com/labki-org/SemanticSchemas/pull/156): a `findPropertyTypeID` race during an in-flight property save wrote `[]` into SMW's `CompositeCache` in-memory layer, and every subsequent request that worker served returned the stale default type until the worker was killed or the property page was manually purged. Recycling after 1000 requests bounds the damage window for any similar pathology without measurably hurting throughput.

### PHP — opcache + APCu

`docker/php/labki-tuning.ini` (new):

- **Opcache** sized for MW+SMW: 256 MB, 20k files, `interned_strings_buffer=32`, `revalidate_freq=60`.
- **APCu** sized 256 MB with `apc.enable_cli=1`.

`enable_cli=1` matters: without it, maintenance scripts (`runJobs.php`, `rebuildData.php`, etc.) silently bypass the user-data cache layer, which can cause CLI-written and web-read state to diverge.

### MediaWiki cache routing

`mediawiki/LocalSettings.defaults.php`:

- `$wgSessionCacheType`, `$wgMessageCacheType` → `CACHE_ACCEL` (align with `$wgMainCacheType`)
- `$wgParserCacheType` → `CACHE_DB` (parser output is durable + cross-process; APCu eviction on a ~hundred-MB cache would hurt)
- `$smwgMainCacheType`, `$smwgQueryResultCacheType` → explicit `CACHE_ACCEL`

Most of these previously resolved to the same backend via `CACHE_ANYTHING`, but being explicit protects against surprises when a deployment overrides `$wgMainCacheType` to e.g. memcached.

Also expanded the existing `$wgJobRunRate = 0` comment to reference the `wiki-jobrunner` container shipped in `labki`.

## Deployment notes

Companion PR in [labki](https://github.com/labki-org/labki) documents these defaults in the deployment repo's README and `LocalSettings.user.php.example` (overrides for memcached / job-rate fallback / upload limits).

## Test plan

- [ ] Docker image builds cleanly (`docker build -t labki-platform:test -f docker/Dockerfile .`)
- [ ] Wiki comes up and serves `Main_Page`
- [ ] APCu active inside the container: `docker compose exec wiki php -r 'var_dump(apcu_enabled());'`
- [ ] Opcache active: `docker compose exec wiki php -r 'var_dump(opcache_get_status(false)["opcache_enabled"]);'`
- [ ] Apache recycling set: `docker compose exec wiki apachectl -t -D DUMP_RUN_CFG | grep -i connections`

🤖 Generated with [Claude Code](https://claude.com/claude-code)