### PR TITLE
Raise Apache worker recycle to 10k and blacklist LocalSettings in opcache

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,12 +17,14 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Apache + PHP tuning for long-lived MediaWiki deployments.
-# MaxConnectionsPerChild bounds Apache worker lifetime so in-process PHP
-# state (SMW's in-memory caches in particular) can't accumulate stale
-# entries indefinitely. Opcache + APCu settings give a sensible baseline
-# for a single-VPS install serving up to ~1000 users/day.
+# Opcache + APCu settings give a sensible baseline for a single-VPS
+# install serving up to ~1000 users/day. Apache's MaxConnectionsPerChild
+# is set to a large value purely as defensive hygiene against long-tail
+# PHP memory leaks. LocalSettings files are opcache-blacklisted so admin
+# config edits take effect immediately.
 COPY docker/apache/labki-tuning.conf /etc/apache2/conf-available/labki-tuning.conf
 COPY docker/php/labki-tuning.ini /usr/local/etc/php/conf.d/zz-labki-tuning.ini
+COPY docker/php/opcache-blacklist.txt /usr/local/etc/php/opcache-blacklist.txt
 RUN a2enconf labki-tuning
 
 # Install Composer

--- a/docker/apache/labki-tuning.conf
+++ b/docker/apache/labki-tuning.conf
@@ -1,12 +1,8 @@
 # Labki Platform — Apache tuning
 #
-# Recycle each Apache worker process after a finite number of requests so
-# long-lived in-process PHP state can't accumulate indefinitely. Without
-# this, mod_php workers serve requests for the life of the container
-# (days to weeks), and any PHP-level cache that lacks a real TTL (e.g.
-# SMW's in-memory CompositeCache layer) holds stale entries forever.
-#
-# 1000 is a compromise: high enough that worker churn is negligible for
-# throughput, low enough that any transient poisoned cache entry is
-# flushed within a few minutes of traffic.
-MaxConnectionsPerChild 1000
+# Recycle each Apache worker process after a finite number of connections as
+# a defensive hygiene measure against long-tail PHP memory leaks in week-plus
+# container uptimes. 10000 is effectively invisible for cache perf (opcache
+# and APCu live in SHM and survive the recycle; only a worker's in-process
+# PHP state restarts cold) but still bounds runaway processes.
+MaxConnectionsPerChild 10000

--- a/docker/php/labki-tuning.ini
+++ b/docker/php/labki-tuning.ini
@@ -10,6 +10,11 @@ opcache.max_accelerated_files=20000
 opcache.revalidate_freq=60
 opcache.validate_timestamps=1
 
+; Exclude LocalSettings and the bootstrap loader from opcache so admin
+; edits to wiki config apply on the next request instead of waiting up
+; to revalidate_freq seconds. MW core/extensions/skins stay cached.
+opcache.blacklist_filename=/usr/local/etc/php/opcache-blacklist.txt
+
 ; APCu: user-data cache backing MediaWiki's CACHE_ACCEL and SMW's
 ; in-memory lookups. `enable_cli=1` matters for maintenance scripts
 ; (runJobs, rebuildData) — without it, CLI invocations silently bypass

--- a/docker/php/opcache-blacklist.txt
+++ b/docker/php/opcache-blacklist.txt
@@ -1,0 +1,12 @@
+# Labki Platform — opcache blacklist
+#
+# Files listed here are never cached by opcache, so edits take effect on
+# the next request instead of waiting for opcache.revalidate_freq. We
+# apply this to LocalSettings and the bootstrap loader because admins
+# routinely edit them for debugging and expect changes to be immediate.
+# Everything else (MediaWiki core, extensions, skins) stays cached.
+/var/www/html/LocalSettings.php
+/opt/labki/mediawiki/bootstrap.php
+/opt/labki/mediawiki/LocalSettings.base.php
+/opt/labki/mediawiki/LocalSettings.defaults.php
+/mw-config/LocalSettings.user.php


### PR DESCRIPTION
## Summary
Follow-up to #29 (2dfaf1b) addressing two reviewer concerns on the cache defaults.

- **Apache: `MaxConnectionsPerChild` 1000 → 10000.** The original value was a workaround for [SemanticSchemas#156](https://github.com/labki-org/SemanticSchemas/issues/156), forcing worker recycling to flush poisoned SMW in-process cache entries. With the root cause fixed upstream in SemanticSchemas, this aggressive recycle is no longer needed and was actively harmful to cache perf: each recycle drops SMW's in-process first-tier cache (CompositeCache local layer, class statics, lazy-loaded property metadata), which a single heavy editing session can burn through in minutes. 10000 is kept purely as defensive hygiene against long-tail PHP memory leaks — at that level worker churn is effectively invisible. Opcache and APCu both live in SHM and are unaffected by recycling either way.
- **PHP: opcache blacklist for LocalSettings.** Previously, edits to `LocalSettings*.php` took up to `opcache.revalidate_freq` (60s) to apply, which is fine in steady state but actively confusing for anyone debugging config. New `opcache.blacklist_filename` excludes: `/var/www/html/LocalSettings.php`, `/opt/labki/mediawiki/bootstrap.php`, `/opt/labki/mediawiki/LocalSettings.base.php`, `/opt/labki/mediawiki/LocalSettings.defaults.php`, `/mw-config/LocalSettings.user.php`. MW core, extensions, and skins remain cached.

## Test plan
- [ ] Image builds cleanly; `a2enconf labki-tuning` still picks up the Apache config
- [ ] `php -i | grep -i opcache.blacklist` inside container shows the blacklist file path
- [ ] `php -i | grep -i MaxConnectionsPerChild` / `apachectl -S` reflects 10000
- [ ] Edit `LocalSettings.user.php` in a running container → change is picked up on next request without waiting for the 60s revalidate window
- [ ] SMW-heavy browsing session does not observe the cold-cache pauses that the previous 1000 value could produce

🤖 Generated with [Claude Code](https://claude.com/claude-code)