### PR TITLE
Route MediaWiki object caches to CACHE_DB

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,11 +17,12 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Apache + PHP tuning for long-lived MediaWiki deployments.
-# Opcache + APCu settings give a sensible baseline for a single-VPS
-# install serving up to ~1000 users/day. Apache's MaxConnectionsPerChild
-# is set to a large value purely as defensive hygiene against long-tail
-# PHP memory leaks. LocalSettings files are opcache-blacklisted so admin
-# config edits take effect immediately.
+# Opcache settings give a sensible baseline for a single-VPS install
+# serving up to ~1000 users/day. Apache's MaxConnectionsPerChild is set
+# to a large value purely as defensive hygiene against long-tail PHP
+# memory leaks. LocalSettings files are opcache-blacklisted so admin
+# config edits take effect immediately. Object caching routes to the
+# database (see LocalSettings.base.php).
 COPY docker/apache/labki-tuning.conf /etc/apache2/conf-available/labki-tuning.conf
 COPY docker/php/labki-tuning.ini /usr/local/etc/php/conf.d/zz-labki-tuning.ini
 COPY docker/php/opcache-blacklist.txt /usr/local/etc/php/opcache-blacklist.txt

--- a/docker/apache/labki-tuning.conf
+++ b/docker/apache/labki-tuning.conf
@@ -3,6 +3,6 @@
 # Recycle each Apache worker process after a finite number of connections as
 # a defensive hygiene measure against long-tail PHP memory leaks in week-plus
 # container uptimes. 10000 is effectively invisible for cache perf (opcache
-# and APCu live in SHM and survive the recycle; only a worker's in-process
-# PHP state restarts cold) but still bounds runaway processes.
+# lives in SHM and survives the recycle; only a worker's in-process PHP
+# state restarts cold) but still bounds runaway processes.
 MaxConnectionsPerChild 10000

--- a/docker/php/labki-tuning.ini
+++ b/docker/php/labki-tuning.ini
@@ -14,11 +14,3 @@ opcache.validate_timestamps=1
 ; edits to wiki config apply on the next request instead of waiting up
 ; to revalidate_freq seconds. MW core/extensions/skins stay cached.
 opcache.blacklist_filename=/usr/local/etc/php/opcache-blacklist.txt
-
-; APCu: user-data cache backing MediaWiki's CACHE_ACCEL and SMW's
-; in-memory lookups. `enable_cli=1` matters for maintenance scripts
-; (runJobs, rebuildData) — without it, CLI invocations silently bypass
-; the cache layer and can write semantics that web workers then miss.
-apc.enabled=1
-apc.enable_cli=1
-apc.shm_size=256M

--- a/mediawiki/LocalSettings.base.php
+++ b/mediawiki/LocalSettings.base.php
@@ -24,9 +24,16 @@ $wgScriptPath = getenv('MW_SCRIPT_PATH') ?: "";
 $wgArticlePath = getenv('MW_ARTICLE_PATH') ?: "/wiki/$1";
 $wgServer = getenv('MW_SERVER') ?: "http://localhost:8080";
 
-// --- Object Cache (APCu) ---
-
-$wgMainCacheType = CACHE_ACCEL;
+// --- Object Cache ---
+//
+// CACHE_DB routes through the MediaWiki object cache table on the same
+// MariaDB instance. It's durable across worker restarts and consistent
+// between web workers and CLI maintenance scripts (runJobs, rebuildData).
+// CACHE_ACCEL (APCu) is faster per-op but splits state across SAPIs:
+// CLI maintenance scripts and Apache workers see different caches, which
+// produces hard-to-diagnose inconsistencies in MW + SMW workloads.
+// Revisit if/when Redis or Memcached is added to the deployment.
+$wgMainCacheType = CACHE_DB;
 $wgMemCachedServers = [];
 
 // --- Image Uploads ---

--- a/mediawiki/LocalSettings.defaults.php
+++ b/mediawiki/LocalSettings.defaults.php
@@ -32,20 +32,14 @@ $wgJobRunRate = 0;
 
 // Cache routing.
 //
-// $wgMainCacheType is set in LocalSettings.base.php to CACHE_ACCEL
-// (APCu). Route session and message caches to the same fast in-process
-// store. ParserCache entries can be multi-MB and benefit from
-// durability across worker restarts, so keep it on the database.
-$wgSessionCacheType = CACHE_ACCEL;
-$wgMessageCacheType = CACHE_ACCEL;
+// All caches route to CACHE_DB to match $wgMainCacheType (set in
+// LocalSettings.base.php). Being explicit protects against surprises if
+// a user override flips $wgMainCacheType to something a given subsystem
+// can't use. SMW caches are left at their defaults (CACHE_ANYTHING),
+// which resolves through $wgMainCacheType.
+$wgSessionCacheType = CACHE_DB;
+$wgMessageCacheType = CACHE_DB;
 $wgParserCacheType  = CACHE_DB;
-
-// SMW caches default to CACHE_ANYTHING which resolves through
-// $wgMainCacheType anyway, but making it explicit is helpful for ops
-// and protects against surprises if a user overrides $wgMainCacheType
-// to something SMW's CompositeCache can't use.
-$smwgMainCacheType = CACHE_ACCEL;
-$smwgQueryResultCacheType = CACHE_ACCEL;
 
 // Footer Badge - Powered by Labki
 $wgFooterIcons['poweredby']['labki'] = [


### PR DESCRIPTION
## Summary
- Route `$wgMainCacheType`, `$wgSessionCacheType`, `$wgMessageCacheType` to `CACHE_DB` and drop explicit `$smwgMainCacheType` / `$smwgQueryResultCacheType` so SMW follows `CACHE_ANYTHING` → main.
- Remove the APCu block from `docker/php/labki-tuning.ini` — nothing routes to it anymore. Opcache is untouched.
- Update related comments in `docker/Dockerfile` and `docker/apache/labki-tuning.conf`.

## Why
`CACHE_ACCEL` (APCu) produced inconsistent failures in production. APCu shared memory is per-SAPI, so Apache web workers and CLI maintenance scripts (`runJobs`, `rebuildData`) sit on separate segments. `apc.enable_cli=1` enables APCu in CLI as *its own* isolated segment — it doesn't bridge SAPIs. SMW's CompositeCache is especially sensitive: state set by the worker that wrote a property's datatype can diverge from what subsequent workers read. Sessions in APCu also get nuked on worker recycle, producing random logouts.

For a single-VPS, ~1000 users/day deployment with local MariaDB, `CACHE_DB` lookups land sub-millisecond and the durability + cross-process consistency eliminates the failure class entirely. The right long-term move (Redis/Memcached as a separate container) is deferred until the deployment grows past a single VPS.

## Test plan
- [ ] Build the platform image cleanly with the new tuning files.
- [ ] Confirm `objectcache` table exists and is being written to (`SELECT COUNT(*) FROM objectcache;` after some traffic).
- [ ] Smoke-test login/logout (session cache via DB).
- [ ] Smoke-test a CLI maintenance script (e.g. `runJobs.php`) and verify a subsequent web request observes the resulting state.
- [ ] Reproduce the SemanticSchemas#156 scenario (in-flight property save + concurrent reads) and confirm no datatype divergence.
- [ ] Verify request latency on a representative page is acceptable post-switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)