### PR TITLE
Restrict captcha triggers to account-creation flows

### DIFF
--- a/mediawiki/extensions.platform.php
+++ b/mediawiki/extensions.platform.php
@@ -37,6 +37,17 @@ wfLoadExtension('DiscussionTools');
 wfLoadExtension('ConfirmEdit');
 $wgCaptchaClass = 'SimpleCaptcha';
 
+// Captchas only guard account-creation flows (ConfirmAccount requests, signup,
+// failed logins). Editing pages — including edits that add external links —
+// must never show a captcha to logged-in users.
+$wgCaptchaTriggers['edit']            = false;
+$wgCaptchaTriggers['create']          = false;
+$wgCaptchaTriggers['addurl']          = false;
+$wgCaptchaTriggers['sendemail']       = false;
+$wgCaptchaTriggers['createaccount']   = true;
+$wgCaptchaTriggers['badlogin']        = true;
+$wgCaptchaTriggers['badloginperuser'] = true;
+
 wfLoadExtension('WikiForum');
 $wgWikiForumAllowAnonymous = false;
 $wgCaptchaTriggers['wikiforum'] = false;


### PR DESCRIPTION
## Summary
- Captcha was firing on page edits whenever an external link was added (the default `addurl` trigger). It's only meant as a thin spam guard on account requests, so this was friction without value.
- Disable captcha on `edit`, `create`, `addurl`, and `sendemail`. Keep it on `createaccount`, `badlogin`, and `badloginperuser` so the ConfirmAccount request form, native signup, and brute-force login attempts are still protected.
- Triggers are now set explicitly so the intent is visible at the call site (rather than relying on ConfirmEdit defaults).

## Test plan
- [ ] Restart MediaWiki / reload workers to pick up `LocalSettings` changes.
- [ ] As a logged-in user, edit a page and add an external link — confirm no captcha is shown on save.
- [ ] Visit `Special:RequestAccount` (ConfirmAccount) — confirm a captcha is shown on the request form.
- [ ] Trigger a few failed logins for the same user — confirm captcha kicks in for `badloginperuser`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)