### PR TITLE
Tweeki: dark mode, footer, DT smoke check, runbook

### DIFF
--- a/ci/smoke-test.sh
+++ b/ci/smoke-test.sh
@@ -113,8 +113,10 @@ if [ "$EXTENSIONS_MODE" = "enabled" ]; then
     echo "[smoke-test] Verifying curated extensions are loaded..."
     # Names match the value the extension registers, which is occasionally
     # the human-readable name rather than the directory name (e.g.
-    # ConfirmAccount registers as "Confirm User Accounts").
-    for ext in SemanticMediaWiki VisualEditor PageForms "Confirm User Accounts"; do
+    # ConfirmAccount registers as "Confirm User Accounts"). Echo and
+    # DiscussionTools are bundled with MW 1.44 but we still gate them
+    # on the curated load so a deliberate disable doesn't go silent.
+    for ext in SemanticMediaWiki VisualEditor PageForms "Confirm User Accounts" Echo DiscussionTools; do
         contains_csv "$EXT_NAMES" "$ext" || fail "extension '$ext' missing in 'enabled' mode."
     done
 else

--- a/docs/tweeki-runbook.md
+++ b/docs/tweeki-runbook.md
@@ -1,0 +1,85 @@
+# Tweeki Runbook
+
+A "wiki-as-website" guide for switching a Labki Platform deployment to use **Tweeki** as the default skin. Vector 2022 stays the platform default; switch to Tweeki when you want a more website-like top-navbar layout.
+
+## What you get with Tweeki on Labki
+
+Bundled into the platform with no extra configuration:
+
+- Top-fixed Bootstrap 5.3 navbar; full-width content (no left rail)
+- Echo notifications inside the user menu, with an unread-count badge on the user dropdown toggle and per-section count badges on the dropdown items
+- VisualEditor wired up (via `$wgVisualEditorSupportedSkins[]`)
+- DiscussionTools renders as expected on talk pages
+- Light / dark theme toggle in the navbar; respects `prefers-color-scheme` on first load and persists choice in `localStorage`
+- Custom academic-blue palette via `--labki-*` CSS variables (overridable per deployment in `MediaWiki:Tweeki.css`)
+- "Powered by Labki Platform" custom footer block (overridable at `MediaWiki:Tweeki-footer-custom`)
+
+## Switching a deployment to Tweeki
+
+### Site-wide
+
+In your `LocalSettings.user.php`:
+
+```php
+$wgDefaultSkin = 'tweeki';
+```
+
+Restart the wiki container. New visitors and any user who hasn't explicitly chosen a skin in their preferences will get Tweeki.
+
+### Per-user
+
+Users can opt in independently via **Special:Preferences → Appearance → Skin → Tweeki**, regardless of `$wgDefaultSkin`.
+
+### Quick preview without switching
+
+Append `?useskin=tweeki` to any wiki URL to render that page with Tweeki for the current request only — useful for smoke-checking before flipping the default.
+
+## MediaWiki: pages worth populating
+
+These pages drive Tweeki's chrome. Edit them like any wiki page; changes take effect immediately.
+
+| Page | What it controls |
+| :--- | :--- |
+| `MediaWiki:Sidebar` | Tweeki reads this for the **left side of the top navbar** (top-level menu groups). Each `* heading` line becomes a navbar dropdown; nested `** Page\|Label` lines become its items. |
+| `MediaWiki:Tweeki-footer-custom` | Wikitext list rendered in the custom footer block. Default value is "Powered by Labki Platform" — replace or extend with About / Contact / Privacy links. |
+| `MediaWiki:Tweeki.css` | Site-level CSS overrides for Tweeki. Use this to retune the `--labki-*` palette for your brand without forking the platform. |
+
+## Known caveats
+
+### VisualEditor under Tweeki
+
+Tweeki isn't in MediaWiki core's default `$wgVisualEditorSupportedSkins`. The platform opts it in (see `mediawiki/extensions.platform.php`), but if you upgrade VE or override that variable, double-check Tweeki is still in the list — otherwise users will fall back to source-mode editing.
+
+### ConfirmAccount + OOUI theme initialization
+
+ConfirmAccount instantiates OOUI widgets before the active skin sets the OOUI theme, which can raise `Cannot use object of type ... as singleton` from `\OOUI\Theme::singleton()`. The platform pre-initializes the singleton in a `SetupAfterCache` hook (`mediawiki/extensions.platform.php`). If you see OOUI singleton errors, check that hook still fires.
+
+### Echo notifications: labels / icons / unread state
+
+Tweeki's `PERSONAL` renderer doesn't surface Echo's per-entry `text` or `icon` directly. The platform handles three workarounds:
+
+- `mediawiki/i18n/en.json` registers the missing `notifications-alert` and `notifications-notice` message keys so Tweeki's `wfMessage($key)` fallback resolves to "Alerts" / "Notices".
+- `resources/styles/labki-tweeki.css` maps `fa-tray::before` to FontAwesome's inbox glyph (FA Free has no `fa-tray`).
+- `resources/scripts/labki-tweeki.js` polls the notifications API and decorates the user dropdown toggle + items with unread-count badges.
+
+If a future Echo or Tweeki upgrade changes the rendering path, those workarounds may stop being needed — re-test on upgrade.
+
+### Dark mode
+
+The toggle button writes `<html data-bs-theme="dark|light">` and persists the choice in `localStorage` under key `labki-theme`. A small inline `<script>` in `<head>` applies the stored preference before paint to avoid a flash of light content.
+
+If you add custom CSS for content elements, make sure it works in both themes — most Bootstrap components adapt automatically, but raw color values you write yourself won't.
+
+### Anonymous users on private wikis
+
+The platform configures Tweeki to hide the user menu (`PERSONAL`), the sidebar tools (`TOOLBOX`), and the subnav from anonymous users on private deployments. Anonymous users see a streamlined navbar with prominent "Log in" and "Request Account" buttons. If you're running a public wiki and want anon users to see the full navbar, override `$wgTweekiSkinHideAnon` in `LocalSettings.user.php`.
+
+## Reverting
+
+To roll back a deployment to Vector 2022:
+
+```php
+$wgDefaultSkin = 'vector-2022';
+```
+
+Users who explicitly chose Tweeki in their preferences will keep Tweeki — they need to switch back via Special:Preferences. The `$wgDefaultSkin` change only affects users with no explicit skin preference.

--- a/mediawiki/i18n/en.json
+++ b/mediawiki/i18n/en.json
@@ -3,5 +3,7 @@
 		"authors": []
 	},
 	"notifications-alert": "Alerts",
-	"notifications-notice": "Notices"
+	"notifications-notice": "Notices",
+	"tweeki-footer-custom": "* Powered by [https://github.com/labki-org/labki-platform Labki Platform]",
+	"labki-toggle-theme": "Toggle light / dark theme"
 }

--- a/mediawiki/i18n/qqq.json
+++ b/mediawiki/i18n/qqq.json
@@ -3,5 +3,7 @@
 		"authors": []
 	},
 	"notifications-alert": "Label for the Echo \"Alerts\" entry inside Tweeki's personal-tools dropdown. Tweeki's PERSONAL renderer falls back to wfMessage($key) when the entry has no outer-level `text`, but core MediaWiki's getPersonalToolsForMakeListItem hoists `text` into `links[0]` — leaving the outer level bare. This message provides the fallback label so the dropdown reads \"Alerts\" instead of the raw key marker.",
-	"notifications-notice": "Label for the Echo \"Notices\" entry inside Tweeki's personal-tools dropdown. See notifications-alert for the full reasoning."
+	"notifications-notice": "Label for the Echo \"Notices\" entry inside Tweeki's personal-tools dropdown. See notifications-alert for the full reasoning.",
+	"tweeki-footer-custom": "Wikitext rendered as a custom footer block under Tweeki. Operators can override at the MediaWiki:Tweeki-footer-custom page to replace or extend the default Labki attribution.",
+	"labki-toggle-theme": "Title / aria-label for the navbar dark-mode toggle button."
 }

--- a/mediawiki/skins.platform.php
+++ b/mediawiki/skins.platform.php
@@ -119,13 +119,52 @@ $wgTweekiSkinNavigationalElements['SPECIALPAGES'] = function ( $skin, $context )
     ];
 };
 
+// Light/dark theme toggle. The actual theme switch is driven by JS in
+// labki-tweeki.js (toggles `<html data-bs-theme>` and persists the
+// choice in localStorage). The button starts with a moon icon; the
+// shim swaps to a sun when dark mode is active. Bootstrap 5.3 styles
+// most components via `data-bs-theme`; the labki-tweeki.css overrides
+// the `--labki-*` palette under `[data-bs-theme="dark"]`.
+//
+// Inject a tiny <script> at the top of <head> that applies the stored
+// theme synchronously before paint, so users with dark preference
+// don't see a flash of light content while ResourceLoader catches up.
+$wgHooks['BeforePageDisplay'][] = static function ( $out, $skin ) {
+    if ( strtolower( $skin->getSkinName() ) !== 'tweeki' ) {
+        return;
+    }
+    $out->addHeadItem(
+        'labki-theme-init',
+        "<script>(function(){try{var t=localStorage.getItem('labki-theme');"
+        . "if(!t&&window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches){t='dark';}"
+        . "if(t==='dark'){document.documentElement.setAttribute('data-bs-theme','dark');}}"
+        . "catch(e){}})();</script>"
+    );
+};
+$wgTweekiSkinNavigationalElements['LABKI-THEME-TOGGLE'] = function ( $skin, $context ) {
+    return [ [
+        'text'  => '',
+        'href'  => '#',
+        'id'    => 'labki-theme-toggle',
+        'icon'  => 'moon',
+        'title' => wfMessage( 'labki-toggle-theme' )->text(),
+    ] ];
+};
+
 // Override navbar-right to include our custom elements before PERSONAL and search
-$wgTweekiSkinCustomNav['navbar-right'] = 'LABKI-LOGIN,SPECIALPAGES,PERSONAL,SEARCH';
+$wgTweekiSkinCustomNav['navbar-right'] = 'LABKI-LOGIN,SPECIALPAGES,PERSONAL,LABKI-THEME-TOGGLE,SEARCH';
 
 // Hide footer metadata (MW version info) from everyone
 $wgTweekiSkinHideAll = [
     'footer-info' => true,
 ];
+
+// Tweeki hides the footer-custom block from logged-in users by default.
+// Override that — our default `tweeki-footer-custom` message renders a
+// "Powered by Labki Platform" attribution that should be visible site-
+// wide. Operators can blank `MediaWiki:Tweeki-footer-custom` to remove
+// it, or replace with their own wikitext list.
+$wgTweekiSkinHideLoggedin = [];
 
 // Show real names in user links (academic context)
 $wgTweekiSkinUseRealnames = true;

--- a/resources/scripts/labki-tweeki.js
+++ b/resources/scripts/labki-tweeki.js
@@ -1,25 +1,86 @@
 /**
  * Labki Tweeki Scripts
  *
- * Echo notifications under Tweeki live inside the user (PERSONAL)
- * dropdown rather than as standalone navbar icons. Echo's per-section
- * count is included in its message text but lost in transit (core's
- * getPersonalToolsForMakeListItem moves `text` into links[0] and Tweeki
- * falls back to `wfMessage($key)`, which gives us countless labels).
+ * Two responsibilities:
  *
- * This script polls notification counts and:
- *   - decorates the user dropdown toggle with a total-unread badge so
- *     the unread state is visible without opening the menu;
- *   - appends per-section counts ("Alerts (2)", "Notices (1)") to the
- *     dropdown items themselves.
+ * 1. Echo notifications under Tweeki live inside the user (PERSONAL)
+ *    dropdown rather than as standalone navbar icons. Per-section
+ *    counts get lost in transit (core's getPersonalToolsForMakeListItem
+ *    moves `text` into links[0] and Tweeki falls back to
+ *    `wfMessage($key)`, which produces label-only strings without the
+ *    count). Poll the notifications API and decorate the user toggle
+ *    + dropdown items with unread-count badges.
+ *
+ * 2. Light/dark theme toggle. Bootstrap 5.3 styles components based
+ *    on `<html data-bs-theme>`; we set it from localStorage on first
+ *    paint, then swap on click of the navbar toggle button. Falls
+ *    back to `prefers-color-scheme` when no preference is stored.
  */
 ( function () {
 	'use strict';
 
-	if ( mw.user.isAnon() ) {
-		return;
+	// === Theme toggle ===========================================
+	var THEME_STORAGE_KEY = 'labki-theme';
+	var TOGGLE_ID = 'labki-theme-toggle';
+
+	function readStoredTheme() {
+		try {
+			return localStorage.getItem( THEME_STORAGE_KEY );
+		} catch ( e ) {
+			return null;
+		}
 	}
 
+	function persistTheme( theme ) {
+		try {
+			localStorage.setItem( THEME_STORAGE_KEY, theme );
+		} catch ( e ) {
+			// localStorage unavailable (private browsing, quota); silent.
+		}
+	}
+
+	function preferredTheme() {
+		var stored = readStoredTheme();
+		if ( stored === 'light' || stored === 'dark' ) {
+			return stored;
+		}
+		if ( window.matchMedia && window.matchMedia( '(prefers-color-scheme: dark)' ).matches ) {
+			return 'dark';
+		}
+		return 'light';
+	}
+
+	function applyTheme( theme ) {
+		document.documentElement.setAttribute( 'data-bs-theme', theme );
+		var toggle = document.getElementById( TOGGLE_ID );
+		if ( toggle ) {
+			var icon = toggle.querySelector( 'span.fa' );
+			if ( icon ) {
+				icon.classList.remove( 'fa-sun', 'fa-moon' );
+				icon.classList.add( theme === 'dark' ? 'fa-sun' : 'fa-moon' );
+			}
+		}
+	}
+
+	function bindThemeToggle() {
+		var toggle = document.getElementById( TOGGLE_ID );
+		if ( !toggle ) {
+			return;
+		}
+		toggle.addEventListener( 'click', function ( e ) {
+			e.preventDefault();
+			var current = document.documentElement.getAttribute( 'data-bs-theme' ) || 'light';
+			var next = current === 'dark' ? 'light' : 'dark';
+			applyTheme( next );
+			persistTheme( next );
+		} );
+	}
+
+	// Apply the user's theme before the page paints to avoid a flash
+	// of light content under a dark preference.
+	applyTheme( preferredTheme() );
+
+	// === Echo notification badges ================================
 	var POLL_INTERVAL_MS = 60 * 1000;
 	var SECTION_TO_PT_ID = {
 		alert: 'pt-notifications-alert',
@@ -40,13 +101,13 @@
 		return toggles[ 0 ] || null;
 	}
 
-	function setBadge( el, count, prefix ) {
+	function setBadge( el, count ) {
 		if ( !el ) {
 			return;
 		}
 		var existing = el.querySelector( ':scope > .labki-notif-badge' );
 		if ( count > 0 ) {
-			var label = ( prefix || '' ) + ( count > 99 ? '99+' : String( count ) );
+			var label = count > 99 ? '99+' : String( count );
 			if ( existing ) {
 				existing.textContent = label;
 			} else {
@@ -60,7 +121,10 @@
 		}
 	}
 
-	function refresh() {
+	function refreshBadges() {
+		if ( mw.user.isAnon() ) {
+			return;
+		}
 		var api = new mw.Api();
 		api.get( {
 			action: 'query',
@@ -88,9 +152,17 @@
 		} );
 	}
 
+	// === Init ===================================================
 	function start() {
-		refresh();
-		setInterval( refresh, POLL_INTERVAL_MS );
+		// Re-apply theme now that the toggle button is in the DOM, so
+		// its icon is in sync with the current `data-bs-theme`.
+		applyTheme( preferredTheme() );
+		bindThemeToggle();
+
+		if ( !mw.user.isAnon() ) {
+			refreshBadges();
+			setInterval( refreshBadges, POLL_INTERVAL_MS );
+		}
 	}
 
 	if ( document.readyState !== 'loading' ) {

--- a/resources/styles/labki-tweeki.css
+++ b/resources/styles/labki-tweeki.css
@@ -18,8 +18,59 @@
 	--labki-bg-subtle:     #f4f6f8;
 	--labki-border:        #d8dde3;
 	--labki-heading:       #1a3a5c;
-	--labki-warning:       var(--labki-warning);
+	--labki-warning:       #f0ad4e;
 	--labki-danger:        #d9534f;
+}
+
+/* Dark theme palette. Bootstrap 5.3 handles most components via
+   `data-bs-theme="dark"`; we just retune the `--labki-*` palette so
+   our custom navbar / heading / link styles match the dark page. */
+[data-bs-theme="dark"] {
+	--labki-primary:       #0d1f33;
+	--labki-primary-light: #173052;
+	--labki-primary-dark:  #050d14;
+	--labki-accent:        #5fa3d6;
+	--labki-accent-hover:  #7cb6e0;
+	--labki-text:          #e6edf3;
+	--labki-text-muted:    #9aa6b3;
+	--labki-bg-subtle:     #1a2230;
+	--labki-border:        #2c3645;
+	--labki-heading:       #b8d4f0;
+	--labki-warning:       #f0ad4e;
+	--labki-danger:        #e25d59;
+}
+
+[data-bs-theme="dark"] body {
+	background-color: #0d1117;
+	color: var(--labki-text);
+}
+
+[data-bs-theme="dark"] #content {
+	background-color: #161b22;
+	color: var(--labki-text);
+}
+
+[data-bs-theme="dark"] footer.footer,
+[data-bs-theme="dark"] #footer {
+	background-color: #0d1117;
+	color: var(--labki-text-muted);
+}
+
+/* === Theme toggle button === */
+/* Strip the default link underline / dropdown caret styling so the
+   icon-only toggle reads as a button. */
+#labki-theme-toggle {
+	color: rgba(255, 255, 255, 0.85) !important;
+	cursor: pointer;
+}
+
+#labki-theme-toggle::after {
+	display: none; /* suppress Bootstrap caret */
+}
+
+#labki-theme-toggle:hover,
+#labki-theme-toggle:focus {
+	color: #fff !important;
 }
 
 /* === Navbar === */


### PR DESCRIPTION
## Summary

Tier 2 of the Tweeki polish plan. Vector 2022 stays the platform default; this PR polishes Tweeki so it's a viable opt-in for deployments that want a wiki-as-website feel.

- **Light/dark theme toggle.** Navbar button writes `<html data-bs-theme>` and persists in `localStorage`. An inline init script in `<head>` applies the stored preference (or `prefers-color-scheme` fallback) before paint to avoid a flash of light content. Bootstrap 5.3 drives the dark styling for its components; we override the `--labki-*` palette under `[data-bs-theme=\"dark\"]` for our custom navbar / heading / link CSS.
- **Custom footer block.** Default `tweeki-footer-custom` message with a "Powered by Labki Platform" entry, and `$wgTweekiSkinHideLoggedin = []` so the block renders for everyone (Tweeki hides it from logged-in users by default). Operators can override at `MediaWiki:Tweeki-footer-custom`.
- **DiscussionTools + Echo** added to the smoke-test curated-extension assertion list. A deliberate disable still passes (`MW_DISABLE_PLATFORM_EXTENSIONS=1`); a regression that drops them silently won't.
- **`docs/tweeki-runbook.md`**: how to switch a deployment to Tweeki, which `MediaWiki:` pages drive the chrome (`Sidebar`, `Tweeki-footer-custom`, `Tweeki.css`), and known caveats (VE supported-skins list, ConfirmAccount OOUI singleton workaround, the three Echo-under-Tweeki workarounds, dark mode implications, anon experience on private wikis).

## Why

Working toward making Tweeki a viable default for production wikis. We already shipped (PR #45):
- Echo notifications render with proper i18n labels and per-section count badges
- A total-unread badge on the user dropdown so unread state is visible without opening the menu
- Tweeki bundled with its own Bootstrap; no chameleon / Bootstrap MW extension dependency

This PR adds the chrome that users expect from a "website" — light/dark toggle, a real footer, plus a runbook so ops can switch a deployment without reading our git history.

## Deliberately deferred

- **Breadcrumb subnav.** Tweeki's `$wgTweekiSkinNavigationalElements` callback system doesn't naturally produce semantic `<ol class=\"breadcrumb\">` markup — items get wrapped in `<a>` or `<span>` and grouped under a `<div class=\"dropdown\">`. Building a proper breadcrumb deserves its own PR with a skin-agnostic helper.

## Test plan

- [x] Manual: dark/light toggle flips the navbar + content palette and persists across page loads
- [x] Manual: dark preference via OS-level `prefers-color-scheme` is honored on first visit (no localStorage entry)
- [x] Manual: footer renders "Powered by Labki Platform" for both anon and logged-in users
- [x] PHP `-l` clean on `mediawiki/*.php`; `node --check` clean on the JS shim; `bash -n` clean on `ci/smoke-test.sh`
- [ ] CI: smoke test (prod×enabled, dev×enabled, prod×disabled) passes — DT + Echo assertions are new
- [ ] Manual: confirm Vector + Citizen still render correctly (no regression — the `BeforePageDisplay` head-item hook gates on `getSkinName() === 'tweeki'`, so Vector/Citizen don't get the inline theme script)

🤖 Generated with [Claude Code](https://claude.com/claude-code)