### PR TITLE
Tweeki: rich edit dropdown + polished user menu

### DIFF
--- a/mediawiki/skins.platform.php
+++ b/mediawiki/skins.platform.php
@@ -82,6 +82,43 @@ $wgTweekiSkinHideAnon = [
     'TOOLBOX'  => true,
 ];
 
+// Surface Tweeki's EDIT-EXT split-button dropdown for everyone. By default
+// Tweeki gates EDIT-EXT-special on the per-user `tweeki-advanced` pref, so
+// the dropdown — which carries Edit source, View history, Move, Delete,
+// Watch, Add category (from SemanticSchemas), etc. — is hidden for non-
+// "advanced" users. Unhide it globally so the rich dropdown is the default.
+//
+// Done via $wgExtensionFunctions because Tweeki's skin.json config is
+// applied by ExtensionRegistry *after* LocalSettings runs, so a plain
+// reassignment here would just be overwritten back to the skin default.
+// Using `unset` is targeted: it pulls only the `EDIT-EXT-special` key
+// without disturbing any other entries an admin may add to this array.
+// We also can't just flip $wgDefaultUserOptions['tweeki-advanced'] — any
+// user who's already touched their preferences page has an empty value
+// stored in user_properties that takes precedence over the default.
+$wgExtensionFunctions[] = static function () {
+    unset( $GLOBALS['wgTweekiSkinHideNonAdvanced']['EDIT-EXT-special'] );
+};
+
+// Hide Tweeki's edit button for users who can't edit the current page (anon
+// users on a private wiki, viewer-only groups, protected pages, etc.). By
+// default Tweeki swaps `edit` for `viewsource` and shows a "View source"
+// button — useful on Wikipedia, but in our context it's a dead end that
+// just prompts a login wall, so we drop the whole element. Admins who can
+// edit see the full dropdown unchanged.
+$wgHooks['SkinTweekiCheckVisibility'][] = static function ( $template, $item ) {
+    if ( $item !== 'EDIT' && $item !== 'EDIT-EXT' && $item !== 'EDIT-EXT-special' ) {
+        return true;
+    }
+    $skin = $template->getSkin();
+    $title = $skin->getTitle();
+    if ( $title === null ) {
+        return true;
+    }
+    $pm = MediaWiki\MediaWikiServices::getInstance()->getPermissionManager();
+    return $pm->userCan( 'edit', $skin->getUser(), $title );
+};
+
 // Custom navbar element: prominent "Log in" and "Request Account" buttons for anon users.
 // Tweeki's PERSONAL element has text-rendering bugs with login-private + createaccount,
 // so we bypass it with a clean custom element and hide PERSONAL for anon (above).
@@ -104,19 +141,56 @@ $wgTweekiSkinNavigationalElements['LABKI-LOGIN'] = function ( $skin, $context ) 
     ];
 };
 
-// Tweeki's default navigation does not surface a Special Pages link, so add
-// one for logged-in users. Anonymous users would just hit a login wall.
-$wgTweekiSkinNavigationalElements['SPECIALPAGES'] = function ( $skin, $context ) {
-    if ( $skin->getSkin()->getUser()->isAnon() ) {
-        return [];
+// Customize the user dropdown for logged-in Tweeki users:
+//  1. Surface a Special Pages link (Tweeki's default has none, and we
+//     pulled it out of navbar-right). Insert after `mytalk` so it lands
+//     in the top group with userpage and Echo's Notices/Alerts, before
+//     Tweeki's divider that precedes `preferences`.
+//  2. Replace the OOUI icon names MediaWiki sets by default (e.g.
+//     `userAvatar`, `userTalk`, `settings`) with FontAwesome names.
+//     Tweeki emits `<span class="fa fa-{icon}"></span>` and ships FA 5
+//     Free Solid, which has no glyphs for the OOUI names — so without
+//     overriding, every entry renders as a blank span. Scoped to Tweeki
+//     because Vector 2022 / Citizen render those OOUI names via their
+//     own sprites and would lose their icons if we clobbered them.
+// Anonymous users would just hit a login wall and PERSONAL is hidden
+// for them via $wgTweekiSkinHideAnon, so skip them entirely.
+$wgHooks['SkinTemplateNavigation::Universal'][] = static function ( $sktemplate, &$links ) {
+    if ( strtolower( $sktemplate->getSkinName() ) !== 'tweeki' ) {
+        return;
     }
-    return [
-        [
-            'text' => wfMessage( 'specialpages' )->text(),
-            'href' => SpecialPage::getTitleFor( 'Specialpages' )->getLocalURL(),
-            'id' => 'pt-specialpages',
-        ],
+    if ( $sktemplate->getUser()->isAnon() ) {
+        return;
+    }
+    $specialpages = [
+        'text' => wfMessage( 'specialpages' )->text(),
+        'href' => SpecialPage::getTitleFor( 'Specialpages' )->getLocalURL(),
+        'id'   => 'pt-specialpages',
+        'icon' => 'list',
     ];
+    if ( isset( $links['user-menu']['mytalk'] ) ) {
+        $links['user-menu'] = wfArrayInsertAfter(
+            $links['user-menu'],
+            [ 'specialpages' => $specialpages ],
+            'mytalk'
+        );
+    } else {
+        $links['user-menu']['specialpages'] = $specialpages;
+    }
+
+    $iconMap = [
+        'userpage'    => 'user',
+        'mytalk'      => 'comments',
+        'preferences' => 'cog',
+        'watchlist'   => 'star',
+        'mycontris'   => 'history',
+        'logout'      => 'sign-out-alt',
+    ];
+    foreach ( $iconMap as $key => $icon ) {
+        if ( isset( $links['user-menu'][$key] ) ) {
+            $links['user-menu'][$key]['icon'] = $icon;
+        }
+    }
 };
 
 // Light/dark theme toggle. The actual theme switch is driven by JS in
@@ -152,7 +226,7 @@ $wgTweekiSkinNavigationalElements['LABKI-THEME-TOGGLE'] = function ( $skin, $con
 };
 
 // Override navbar-right to include our custom elements before PERSONAL and search
-$wgTweekiSkinCustomNav['navbar-right'] = 'LABKI-LOGIN,SPECIALPAGES,PERSONAL,LABKI-THEME-TOGGLE,SEARCH';
+$wgTweekiSkinCustomNav['navbar-right'] = 'LABKI-LOGIN,PERSONAL,LABKI-THEME-TOGGLE,SEARCH';
 
 // Hide footer metadata (MW version info) from everyone
 $wgTweekiSkinHideAll = [


### PR DESCRIPTION
## Summary

Polishes the Tweeki skin's edit area and user dropdown so the wiki feels
website-like by default while still surfacing the full set of wiki actions
to logged-in editors.

- **User dropdown:** Move the *Special pages* link out of `navbar-right`
  into the user dropdown next to Echo's Notices/Alerts (after `mytalk`,
  before the divider Tweeki renders ahead of Preferences). Also replace
  the OOUI icon names MediaWiki sets by default (`userAvatar`, `userTalk`,
  `settings`, …) with FontAwesome names so every entry actually renders an
  icon — Tweeki ships FA 5 Free Solid which has no glyphs for OOUI names.
  Hook scoped to Tweeki so Vector 2022 / Citizen keep their own icon
  sprites untouched.

- **Edit area:** Surface the rich `EDIT-EXT` split-button dropdown
  (Edit / Edit source / View history / Move / Delete / Watch / Refresh,
  plus *Add category* from SemanticSchemas and *Edit with form* from
  PageForms when applicable) for everyone, instead of the single wide
  Edit button. The skin gated this behind a per-user `tweeki-advanced`
  preference; we unset that gate via `$wgExtensionFunctions` because
  Tweeki's `skin.json` config is applied by ExtensionRegistry *after*
  LocalSettings, so a plain reassignment would be silently overwritten.

- **No edit button when you can't edit:** Add a `SkinTweekiCheckVisibility`
  hook that returns `false` for `EDIT` / `EDIT-EXT` / `EDIT-EXT-special`
  when `PermissionManager::userCan( 'edit', user, title )` is false. Anon
  users on the private wiki no longer see a button that just routes them
  to a login wall.

## Test plan

- [ ] Anonymous view of any page in Tweeki: no edit button anywhere on
      the page; sidebar-right is just the TOC slot
- [ ] Logged-in admin on a content page: split Edit button + caret →
      dropdown shows Edit source, View history, divider, Move, Delete,
      Protect, Watch, Refresh
- [ ] Logged-in admin on a category page (with SemanticSchemas):
      *Add category*, *New page*, *Generate form* show in the dropdown
- [ ] Logged-in admin on a form-bound page (with PageForms): *Edit with
      form* becomes the primary button, plain *Edit source* moves into
      the dropdown
- [ ] User dropdown (top-right username menu): every entry has an icon
      — 👤 User page, 💬 Talk, 📋 Special pages, ⚙️ Preferences,
      ⭐ Watchlist, 🕐 Contributions, 🚪 Log out — and Echo's
      Notices/Alerts still render correctly above
- [ ] Anon view: no Special pages entry leaks anywhere
- [ ] Switch skin to Vector 2022: user-menu icons unaffected (still
      uses MW's OOUI sprite); no other regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)