### PR TITLE
Pin SRF to dev-master for MW 1.44 forward-compat

### DIFF
--- a/composer/composer.platform.json
+++ b/composer/composer.platform.json
@@ -1,7 +1,7 @@
 {
     "require": {
         "mediawiki/semantic-media-wiki": "~6.0",
-        "mediawiki/semantic-result-formats": "~5.2",
+        "mediawiki/semantic-result-formats": "dev-master#7aed73963d6358cbd7567d3d309487e810d6526a",
         "mediawiki/page-forms": "~6",
         "mediawiki/maps": "~12",
         "mediawiki/semantic-extra-special-properties": "~4",
@@ -10,6 +10,8 @@
         "mediawiki/mermaid": "~6.0.1",
         "scssphp/scssphp": "~1.11"
     },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "config": {
         "allow-plugins": {
             "composer/installers": true,


### PR DESCRIPTION
## Summary

- SRF 5.2.0 (the only published 5.x release; both `~5.1` and `~5.2` resolve to it) is broken on MediaWiki 1.44 because MW 1.44 dropped the global `\Html` and `\Title` class aliases that ~30 SRF source files rely on.
- Affected formats include `calendar`, `eventcalendar`, `gallery`, `datatables`, `gantt`, `carousel`, `tagcloud`, `slideshow`, `tree`, `jqplot`, `dygraphs`, `sparkline`, `timeline`, `timeseries`, `valuerank`, `widget`, `media`, `boilerplate`, `d3`, `graph`, `process`, `array`, `jitgraph`, and `filtered` (MapView) — roughly half of SRF's format printers fatal with `Class \"Html\" not found` or `Class \"Title\" not found` as soon as they're exercised.
- Upstream master has forward-ported all imports (`use MediaWiki\\Html\\Html;`, `use MediaWiki\\Title\\Title;`) but no 5.3.x / 6.0.x tag has been cut yet, so we pin to a specific master commit (`7aed7396`) for reproducibility.
- Adds `minimum-stability: dev` + `prefer-stable: true` so only the explicitly dev-pinned SRF dep falls back to a dev version; everything else continues to resolve to stable releases.

## Why now

The image base (`mediawiki:1.44`) floats to the latest 1.44.x point release on rebuild, so a recent MW patch hardening the deprecated alias surfaced this latent forward-compat gap. Symptom: `https://new-wiki.aharoni-lab.com/wiki/Calendar` and any save touching a page with `{{#ask:...|format=calendar}}` or `format=eventcalendar` returned 500. Verified fix: master's `EventCalendar.php` imports `use MediaWiki\\Html\\Html;`, which the broken 5.2.0 release does not.

## Trade-off vs. the alternatives considered

- **Patch the 30 affected files in the Dockerfile.** Doable with sed but fragile, and the patch surface grows as users exercise new formats.
- **Wait for SRF 5.3.0 / 6.0.0.** No tag activity; not viable for a production fix.
- **Pin to dev-master (this PR).** Minimal change, single source of truth, easy to revert when a real tag ships. Risk: pulls in unrelated unreleased changes — pinning to a specific commit hash mitigates this.

## Test plan

- [ ] Rebuild the platform image and confirm `composer show mediawiki/semantic-result-formats` reports `dev-master 7aed739...` inside the container.
- [ ] Load `https://new-wiki.aharoni-lab.com/wiki/Calendar?action=purge` and confirm 200 response.
- [ ] Save a page containing `{{#ask: [[Category:Event]] |?Has start date=date |format=eventcalendar}}` and confirm save completes without 500.
- [ ] Spot-check at least one other previously-broken format (e.g. `format=gallery` or `format=datatables`) on a page that uses it.
- [ ] Verify CI smoke test still passes against the rebuilt image.

## Follow-up

When SRF tags 5.3.0 / 6.0.0 (whichever lands first with the import fixes):

1. Replace `dev-master#<hash>` with the tag constraint (e.g. `~6.0`).
2. Drop the `minimum-stability` and `prefer-stable` lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)