### PR TITLE
Enable bundled SyntaxHighlight extension

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,9 +11,10 @@ LABEL org.opencontainers.image.version.mediawiki="${MEDIAWIKI_VERSION}"
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 WORKDIR /var/www/html
 
-# Install build dependencies (git: extensions, unzip: composer, mariadb-client: DB checks)
+# Install build dependencies (git: extensions, unzip: composer, mariadb-client: DB checks,
+# python3: SyntaxHighlight_GeSHi's bundled pygmentize is a Python script).
 RUN apt-get update && apt-get install -y \
-    git unzip ca-certificates mariadb-client curl \
+    git unzip ca-certificates mariadb-client curl python3 \
     && rm -rf /var/lib/apt/lists/*
 
 # Apache + PHP tuning for long-lived MediaWiki deployments.

--- a/mediawiki/extensions.platform.php
+++ b/mediawiki/extensions.platform.php
@@ -35,6 +35,7 @@ wfLoadExtension('Lockdown');
 
 wfLoadExtension('Echo');
 wfLoadExtension('Linter');
+wfLoadExtension('SyntaxHighlight_GeSHi');
 
 wfLoadExtension('VisualEditor');
 $wgDefaultUserOptions['visualeditor-editor'] = 'visualeditor';


### PR DESCRIPTION
## Summary
- Load MediaWiki 1.44's bundled `SyntaxHighlight_GeSHi` extension (now Pygments-based, 500+ languages, WMF-maintained) so wiki pages can use `<syntaxhighlight lang="...">` code blocks.
- Add `python3` to the Docker image. The extension's bundled `pygmentize` (`extensions/SyntaxHighlight_GeSHi/pygments/pygmentize`) is a Python script and the upstream `mediawiki:1.44` image (Debian-based PHP-Apache) does not ship Python.
- No version pin or composer entry needed — the extension ships in the MW tarball, so its version is locked to MW 1.44.

## Test plan
- [x] Local build succeeds (`docker compose -f compose/docker-compose.dev.yml build wiki`)
- [x] Container becomes healthy
- [x] `python3 --version` → 3.13.5 in the container
- [x] Bundled `pygmentize -V` → Pygments 2.19.2
- [x] `ExtensionRegistry` reports `SyntaxHighlight 2.0` loaded
- [x] Parser-level render of `<syntaxhighlight lang="python">` produces `<div class="mw-highlight mw-highlight-lang-python">` with proper Pygments token spans
- [ ] Manual smoke: create a page with a `<syntaxhighlight lang="python" line>` block and confirm rendering in the browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)