### PR TITLE
Enable TemplateStyles extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CONTRIBUTING.md with contributor guidelines
 - CHANGELOG.md for tracking releases
 - CI badges in README
+- TemplateStyles extension (bundled with MediaWiki 1.44) loaded by default. Schema bundles can now ship per-template CSS via `<templatestyles src="Template:Foo/styles.css" />` without requiring site-wide `editsitecss` rights for deploy bots.
 
 ## [0.1.0] - 2026-01-13
 

--- a/mediawiki/extensions.platform.php
+++ b/mediawiki/extensions.platform.php
@@ -37,6 +37,12 @@ wfLoadExtension('Echo');
 wfLoadExtension('Linter');
 wfLoadExtension('SyntaxHighlight_GeSHi');
 
+// TemplateStyles lets templates ship sanitized, scoped CSS via
+// <templatestyles src="Template:Foo/styles.css" /> without needing
+// site-wide editsitecss rights. Schema bundles (e.g. SchemaSync) use
+// this to package per-template CSS alongside their templates.
+wfLoadExtension('TemplateStyles');
+
 wfLoadExtension('VisualEditor');
 $wgDefaultUserOptions['visualeditor-editor'] = 'visualeditor';
 // MediaWiki's default $wgVisualEditorSupportedSkins covers


### PR DESCRIPTION
## Summary
- Loads TemplateStyles, bundled with MediaWiki since 1.31, so schema bundles (e.g. SchemaSync) can ship per-template CSS via `<templatestyles src="Template:Foo/styles.css" />` without requiring site-wide `editsitecss` rights for deploy bots — TemplateStyles sanitizes and auto-scopes the CSS at parse time.
- One-line addition to `extensions.platform.php` (under "Bundled MediaWiki Extensions"), plus CHANGELOG entry. No other changes.

## Why
Schema-bundle CSS distribution has historically required either privileged bot rights (editing `MediaWiki:Common.css`) or platform-side bundling. TemplateStyles is the purpose-built MediaWiki mechanism for shipping sandboxed CSS alongside templates. Enabling it unblocks design-system bundles that travel with their template definitions — no new bot rights, no platform coupling per design release.

## Test plan
- [ ] Build platform image; on dev wiki, confirm `Special:Version` lists TemplateStyles
- [ ] Create `Template:UI/Test/styles.css` with a small rule and a `Template:UI/Test` that includes `<templatestyles src="Template:UI/Test/styles.css" />`; confirm the sanitized CSS renders on a page that transcludes the template
- [ ] Verify the CSS is auto-scoped to `.mw-parser-output` and doesn't leak globally

🤖 Generated with [Claude Code](https://claude.com/claude-code)