### PR TITLE
Promote common chrome from per-wiki Common.css/js to platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CONTRIBUTING.md with contributor guidelines
 - CHANGELOG.md for tracking releases
 - CI badges in README
+- Surface and elevation design tokens (`--labki-surface`, `--labki-shadow-sm`, `--labki-shadow-md`, `--labki-radius`) — schema bundles and per-wiki CSS can compose against these and flip cleanly with `[data-bs-theme="dark"]`.
+- Right sidebar collapse drawer: `js/labki-tweeki.js` injects a viewport-anchored pull-tab button that toggles `body.sidebar-collapsed`; state persists in `localStorage["labki.sidebarCollapsed"]`.
+- Page-actions relocation: the action-button cluster (Edit, History, …) is lifted out of `#sidebar-right` and re-anchored at the top-right of the content card, so it stays visible when the sidebar is collapsed and on narrow windows.
+- `<html>` is tagged with `is-anon` or `is-logged-in` so per-wiki CSS can render login-conditional UI without a DOM round-trip.
+- Timestamp localization: SMW-rendered UTC ISO timestamps in `<time datetime="...">` elements (preferred) and bare ISO strings inside wikitext tables are converted to the viewer's locale via `toLocaleString()`. Idempotent.
 
 ## [0.1.0] - 2026-01-13
 

--- a/compose/docker-compose.dev.yml
+++ b/compose/docker-compose.dev.yml
@@ -28,6 +28,14 @@ services:
       # Pass through from host env so smoke-test.sh can drive enabled/disabled
       # modes; defaults to 0 (extensions loaded) for normal dev use.
       MW_DISABLE_PLATFORM_EXTENSIONS: ${MW_DISABLE_PLATFORM_EXTENSIONS:-0}
+    volumes:
+      # Live-mount chrome resources so labki-tweeki.{js,css} edits flow
+      # without an image rebuild. Mount the three subdirs the Dockerfile
+      # COPYs in (assets/, styles/, scripts/) — NOT the parent resources/,
+      # which would shadow MediaWiki core's own resources/Resources.php.
+      - ../resources/assets:/var/www/html/resources/assets
+      - ../resources/styles:/var/www/html/resources/styles
+      - ../resources/scripts:/var/www/html/resources/scripts
     # volumes:
     #   - ../mediawiki:/opt/labki/mediawiki
     #   - ../../MyExtension:/var/www/html/extensions/MyExtension

--- a/mediawiki/skins.platform.php
+++ b/mediawiki/skins.platform.php
@@ -193,26 +193,32 @@ $wgHooks['SkinTemplateNavigation::Universal'][] = static function ( $sktemplate,
     }
 };
 
-// Light/dark theme toggle. The actual theme switch is driven by JS in
-// labki-tweeki.js (toggles `<html data-bs-theme>` and persists the
-// choice in localStorage). The button starts with a moon icon; the
-// shim swaps to a sun when dark mode is active. Bootstrap 5.3 styles
-// most components via `data-bs-theme`; the labki-tweeki.css overrides
-// the `--labki-*` palette under `[data-bs-theme="dark"]`.
+// Inline <head> bootstrap that applies persisted UI state synchronously
+// before paint. Two pieces of state, both keyed in localStorage and
+// mirrored on <html>:
 //
-// Inject a tiny <script> at the top of <head> that applies the stored
-// theme synchronously before paint, so users with dark preference
-// don't see a flash of light content while ResourceLoader catches up.
+//   * Theme (data-bs-theme) — the actual toggle is in labki-tweeki.js;
+//     this just avoids a flash of light content for users with dark
+//     preference while ResourceLoader catches up.
+//   * Sidebar collapse state (html.sidebar-collapsed) — without this,
+//     users with a previously-collapsed sidebar would see it render
+//     expanded, then animate shut once labki-tweeki.js runs. Setting
+//     the class on <html> (not <body>) is what lets us do this in a
+//     head script — <body> doesn't exist yet at this point.
 $wgHooks['BeforePageDisplay'][] = static function ( $out, $skin ) {
     if ( strtolower( $skin->getSkinName() ) !== 'tweeki' ) {
         return;
     }
     $out->addHeadItem(
-        'labki-theme-init',
-        "<script>(function(){try{var t=localStorage.getItem('labki-theme');"
+        'labki-ui-state-init',
+        "<script>(function(){try{"
+        . "var t=localStorage.getItem('labki-theme');"
         . "if(!t&&window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches){t='dark';}"
-        . "if(t==='dark'){document.documentElement.setAttribute('data-bs-theme','dark');}}"
-        . "catch(e){}})();</script>"
+        . "if(t==='dark'){document.documentElement.setAttribute('data-bs-theme','dark');}"
+        . "if(localStorage.getItem('labki.sidebarCollapsed')==='true'){"
+        . "document.documentElement.classList.add('sidebar-collapsed');"
+        . "}"
+        . "}catch(e){}})();</script>"
     );
 };
 $wgTweekiSkinNavigationalElements['LABKI-THEME-TOGGLE'] = function ( $skin, $context ) {

--- a/resources/scripts/labki-tweeki.js
+++ b/resources/scripts/labki-tweeki.js
@@ -165,8 +165,14 @@
 			return;
 		}
 
+		// The class lives on <html> rather than <body> so the inline
+		// <head> bootstrap script in skins.platform.php can apply it
+		// before paint. By the time we run, that script has likely
+		// already set the class — classList.add is idempotent, so the
+		// guard below is just for browsers without localStorage support.
+		var html = document.documentElement;
 		if ( readSidebarCollapsed() ) {
-			document.body.classList.add( 'sidebar-collapsed' );
+			html.classList.add( 'sidebar-collapsed' );
 		}
 
 		var btn = document.createElement( 'button' );
@@ -176,12 +182,12 @@
 		btn.setAttribute( 'title', 'Toggle side panel' );
 		btn.setAttribute(
 			'aria-expanded',
-			document.body.classList.contains( 'sidebar-collapsed' ) ? 'false' : 'true'
+			html.classList.contains( 'sidebar-collapsed' ) ? 'false' : 'true'
 		);
 		btn.appendChild( buildSidebarChevron() );
 
 		btn.addEventListener( 'click', function () {
-			var collapsed = document.body.classList.toggle( 'sidebar-collapsed' );
+			var collapsed = html.classList.toggle( 'sidebar-collapsed' );
 			btn.setAttribute( 'aria-expanded', collapsed ? 'false' : 'true' );
 			writeSidebarCollapsed( collapsed );
 		} );
@@ -191,15 +197,18 @@
 
 	// === Page actions relocation ================================
 	// Find the action-button cluster (Edit + dropdown) inside the
-	// sidebar. Tweeki wraps page actions in different elements
-	// depending on config; try a sequence of likely selectors.
+	// sidebar. Tweeki wraps the EDIT-EXT element in `btn-group`
+	// (per the tweeki-sidebar-right-wrapperclass message); the
+	// MediaWiki-standard #p-cactions / #p-views IDs cover non-Tweeki
+	// layouts. We deliberately don't fall back to `.dropdown` —
+	// Tweeki's TOC also uses that class, and grabbing it would
+	// relocate the scroll-spy panel by accident.
 	function findActionGroup( sidebar ) {
 		var selectors = [
 			'#p-cactions',
 			'#p-views',
 			'.tweeki-cactions',
-			'.btn-group',
-			'.dropdown'
+			'.btn-group'
 		];
 		for ( var i = 0; i < selectors.length; i++ ) {
 			var match = sidebar.querySelector( selectors[ i ] );

--- a/resources/scripts/labki-tweeki.js
+++ b/resources/scripts/labki-tweeki.js
@@ -149,14 +149,14 @@
 	// True when #sidebar-right has rendered content worth collapsing.
 	// Called after relocatePageActions(), so the action cluster has
 	// already been lifted out — what remains is TOC, portals, etc.
-	// If the sidebar's only content was the action cluster, there's
-	// nothing left to hide and the toggle is pointless.
+	// Structural check (children.length) rather than textContent: Tweeki
+	// renders the scroll-spy TOC as an empty <div id="tweekiTOC"> that
+	// gets populated client-side AFTER our init runs, so a text-based
+	// check would skip the toggle on every page with a yet-to-be-filled
+	// TOC. If the sidebar's only content was the action cluster,
+	// relocatePageActions has emptied it and we correctly skip.
 	function sidebarHasContent( sidebar ) {
-		if ( sidebar.textContent.trim().length > 0 ) {
-			return true;
-		}
-		// Catch icon-only / embed-only sidebars that have no text.
-		return !!sidebar.querySelector( 'img, svg, hr, video, iframe' );
+		return sidebar.children.length > 0;
 	}
 
 	function installSidebarToggle() {

--- a/resources/scripts/labki-tweeki.js
+++ b/resources/scripts/labki-tweeki.js
@@ -1,23 +1,51 @@
 /**
  * Labki Tweeki Scripts
  *
- * Two responsibilities:
+ * Responsibilities:
  *
- * 1. Echo notifications under Tweeki live inside the user (PERSONAL)
- *    dropdown rather than as standalone navbar icons. Per-section
- *    counts get lost in transit (core's getPersonalToolsForMakeListItem
- *    moves `text` into links[0] and Tweeki falls back to
- *    `wfMessage($key)`, which produces label-only strings without the
- *    count). Poll the notifications API and decorate the user toggle
- *    + dropdown items with unread-count badges.
- *
- * 2. Light/dark theme toggle. Bootstrap 5.3 styles components based
+ * 1. Light/dark theme toggle. Bootstrap 5.3 styles components based
  *    on `<html data-bs-theme>`; we set it from localStorage on first
  *    paint, then swap on click of the navbar toggle button. Falls
  *    back to `prefers-color-scheme` when no preference is stored.
+ *
+ * 2. Tag <html> with `is-anon` or `is-logged-in` so per-wiki CSS can
+ *    render login-conditional UI without a DOM round-trip.
+ *
+ * 3. Right sidebar collapse drawer. Inject a viewport-anchored
+ *    pull-tab button that toggles `body.sidebar-collapsed`. State
+ *    persists in localStorage. Styles in labki-tweeki.css section
+ *    "Right sidebar collapse drawer".
+ *
+ * 4. Page actions relocation. Lift the action-button cluster (Edit,
+ *    History, …) out of #sidebar-right and re-anchor it at the
+ *    top-right of the content card so it stays visible when the
+ *    sidebar is collapsed and on narrow windows. Styles in
+ *    labki-tweeki.css section "Page actions relocation".
+ *
+ * 5. Timestamp localization. Convert SMW-rendered UTC ISO timestamps
+ *    (semantic <time datetime="..."> elements and bare ISO strings
+ *    in wikitext tables) to the viewer's locale via toLocaleString().
+ *
+ * 6. Echo notifications under Tweeki: notifications live inside the
+ *    user (PERSONAL) dropdown rather than as standalone navbar
+ *    icons. Per-section counts get lost in transit (core's
+ *    getPersonalToolsForMakeListItem moves `text` into links[0] and
+ *    Tweeki falls back to `wfMessage($key)`, which produces label-
+ *    only strings without the count). Poll the notifications API
+ *    and decorate the user toggle + dropdown items with unread-
+ *    count badges.
  */
 ( function () {
 	'use strict';
+
+	// === Login state HTML tagging ===============================
+	// Tag <html> with `is-anon` or `is-logged-in` so per-wiki CSS
+	// can render login-conditional UI without a DOM round-trip.
+	// Runs immediately so the class is in place before any layout-
+	// affecting init.
+	document.documentElement.classList.add(
+		mw.user.isAnon() ? 'is-anon' : 'is-logged-in'
+	);
 
 	// === Theme toggle ===========================================
 	var THEME_STORAGE_KEY = 'labki-theme';
@@ -79,6 +107,179 @@
 	// Apply the user's theme before the page paints to avoid a flash
 	// of light content under a dark preference.
 	applyTheme( preferredTheme() );
+
+	// === Sidebar collapse drawer ================================
+	var SIDEBAR_STORAGE_KEY = 'labki.sidebarCollapsed';
+	var SVG_NS = 'http://www.w3.org/2000/svg';
+
+	function readSidebarCollapsed() {
+		try {
+			return localStorage.getItem( SIDEBAR_STORAGE_KEY ) === 'true';
+		} catch ( e ) {
+			return false;
+		}
+	}
+
+	function writeSidebarCollapsed( collapsed ) {
+		try {
+			localStorage.setItem( SIDEBAR_STORAGE_KEY, collapsed ? 'true' : 'false' );
+		} catch ( e ) {
+			// localStorage unavailable; non-fatal.
+		}
+	}
+
+	// Feather-style chevron-left icon, built via DOM. CSS rotates it
+	// 180deg when sidebar is collapsed so it reads "pull me out".
+	function buildSidebarChevron() {
+		var svg = document.createElementNS( SVG_NS, 'svg' );
+		svg.setAttribute( 'viewBox', '0 0 24 24' );
+		svg.setAttribute( 'fill', 'none' );
+		svg.setAttribute( 'stroke', 'currentColor' );
+		svg.setAttribute( 'stroke-width', '2.5' );
+		svg.setAttribute( 'stroke-linecap', 'round' );
+		svg.setAttribute( 'stroke-linejoin', 'round' );
+		svg.setAttribute( 'aria-hidden', 'true' );
+
+		var polyline = document.createElementNS( SVG_NS, 'polyline' );
+		polyline.setAttribute( 'points', '15 18 9 12 15 6' );
+		svg.appendChild( polyline );
+		return svg;
+	}
+
+	function installSidebarToggle() {
+		if ( !document.getElementById( 'sidebar-right' ) ) {
+			return;
+		}
+
+		if ( readSidebarCollapsed() ) {
+			document.body.classList.add( 'sidebar-collapsed' );
+		}
+
+		var btn = document.createElement( 'button' );
+		btn.type = 'button';
+		btn.className = 'sidebar-toggle';
+		btn.setAttribute( 'aria-label', 'Toggle side panel' );
+		btn.setAttribute( 'title', 'Toggle side panel' );
+		btn.setAttribute(
+			'aria-expanded',
+			document.body.classList.contains( 'sidebar-collapsed' ) ? 'false' : 'true'
+		);
+		btn.appendChild( buildSidebarChevron() );
+
+		btn.addEventListener( 'click', function () {
+			var collapsed = document.body.classList.toggle( 'sidebar-collapsed' );
+			btn.setAttribute( 'aria-expanded', collapsed ? 'false' : 'true' );
+			writeSidebarCollapsed( collapsed );
+		} );
+
+		document.body.appendChild( btn );
+	}
+
+	// === Page actions relocation ================================
+	// Find the action-button cluster (Edit + dropdown) inside the
+	// sidebar. Tweeki wraps page actions in different elements
+	// depending on config; try a sequence of likely selectors.
+	function findActionGroup( sidebar ) {
+		var selectors = [
+			'#p-cactions',
+			'#p-views',
+			'.tweeki-cactions',
+			'.btn-group',
+			'.dropdown'
+		];
+		for ( var i = 0; i < selectors.length; i++ ) {
+			var match = sidebar.querySelector( selectors[ i ] );
+			if ( match ) {
+				return match;
+			}
+		}
+		return null;
+	}
+
+	function relocatePageActions() {
+		var sidebar = document.getElementById( 'sidebar-right' );
+		if ( !sidebar ) {
+			return;
+		}
+		var group = findActionGroup( sidebar );
+		if ( !group ) {
+			return;
+		}
+		var contentBody = document.querySelector( '.mw-body' ) ||
+			document.getElementById( 'content' );
+		if ( !contentBody ) {
+			return;
+		}
+
+		var holder = document.createElement( 'div' );
+		holder.className = 'page-actions';
+		holder.appendChild( group );
+		contentBody.insertBefore( holder, contentBody.firstChild );
+	}
+
+	// === Timestamp localization =================================
+	// SMW's #-F[Y-m-d\TH:i:s\Z] format renders dates as raw UTC ISO
+	// strings, which read confusingly to viewers in other timezones.
+	// Convert to the viewer's locale via toLocaleString().
+	//
+	// Two paths:
+	//   1. Semantic <time datetime="..."> elements anywhere on the
+	//      page — preferred. Visible text is replaced; the datetime
+	//      attribute stays machine-readable.
+	//   2. Bare ISO strings inside any wikitext-rendered table cell
+	//      — backstop for legacy SMW table conventions. The regex
+	//      is strictly anchored, so false positives are not a real
+	//      concern.
+	// Idempotent via data-localized="true" marker.
+	function formatLocalDateTime( d ) {
+		return d.toLocaleString( undefined, {
+			year:         'numeric',
+			month:        'short',
+			day:          'numeric',
+			hour:         '2-digit',
+			minute:       '2-digit',
+			timeZoneName: 'short'
+		} );
+	}
+
+	function localizeTimestamps() {
+		var i, el, d, text;
+
+		var times = document.querySelectorAll( 'time[datetime]' );
+		for ( i = 0; i < times.length; i++ ) {
+			el = times[ i ];
+			if ( el.dataset.localized === 'true' ) {
+				continue;
+			}
+			d = new Date( el.getAttribute( 'datetime' ) );
+			if ( isNaN( d.getTime() ) ) {
+				continue;
+			}
+			el.textContent = formatLocalDateTime( d );
+			el.dataset.localized = 'true';
+		}
+
+		var iso = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/;
+		var cells = document.querySelectorAll(
+			'.mw-parser-output table td, .mw-parser-output table th'
+		);
+		for ( i = 0; i < cells.length; i++ ) {
+			el = cells[ i ];
+			if ( el.dataset.localized === 'true' ) {
+				continue;
+			}
+			text = el.textContent.trim();
+			if ( !iso.test( text ) ) {
+				continue;
+			}
+			d = new Date( text );
+			if ( isNaN( d.getTime() ) ) {
+				continue;
+			}
+			el.textContent = formatLocalDateTime( d );
+			el.dataset.localized = 'true';
+		}
+	}
 
 	// === Echo notification badges ================================
 	var POLL_INTERVAL_MS = 60 * 1000;
@@ -158,6 +359,10 @@
 		// its icon is in sync with the current `data-bs-theme`.
 		applyTheme( preferredTheme() );
 		bindThemeToggle();
+
+		installSidebarToggle();
+		relocatePageActions();
+		localizeTimestamps();
 
 		if ( !mw.user.isAnon() ) {
 			refreshBadges();

--- a/resources/scripts/labki-tweeki.js
+++ b/resources/scripts/labki-tweeki.js
@@ -146,8 +146,22 @@
 		return svg;
 	}
 
+	// True when #sidebar-right has rendered content worth collapsing.
+	// Called after relocatePageActions(), so the action cluster has
+	// already been lifted out — what remains is TOC, portals, etc.
+	// If the sidebar's only content was the action cluster, there's
+	// nothing left to hide and the toggle is pointless.
+	function sidebarHasContent( sidebar ) {
+		if ( sidebar.textContent.trim().length > 0 ) {
+			return true;
+		}
+		// Catch icon-only / embed-only sidebars that have no text.
+		return !!sidebar.querySelector( 'img, svg, hr, video, iframe' );
+	}
+
 	function installSidebarToggle() {
-		if ( !document.getElementById( 'sidebar-right' ) ) {
+		var sidebar = document.getElementById( 'sidebar-right' );
+		if ( !sidebar || !sidebarHasContent( sidebar ) ) {
 			return;
 		}
 
@@ -360,8 +374,11 @@
 		applyTheme( preferredTheme() );
 		bindThemeToggle();
 
-		installSidebarToggle();
+		// relocatePageActions runs first so installSidebarToggle sees the
+		// sidebar in its final state — if the action cluster was the
+		// sidebar's only content, the toggle won't install.
 		relocatePageActions();
+		installSidebarToggle();
 		localizeTimestamps();
 
 		if ( !mw.user.isAnon() ) {

--- a/resources/scripts/labki-tweeki.js
+++ b/resources/scripts/labki-tweeki.js
@@ -19,7 +19,11 @@
  * 4. Page actions relocation. Lift the action-button cluster (Edit,
  *    History, …) out of #sidebar-right and re-anchor it at the
  *    top-right of the content card so it stays visible when the
- *    sidebar is collapsed and on narrow windows. Styles in
+ *    sidebar is collapsed and on narrow windows. Skipped under
+ *    VisualEditor (`?veaction=edit`), whose own Save button claims
+ *    the same top-right slot — relocating ours would overlap it.
+ *    Edit-source (action=edit) and Edit-with-form (Special:FormEdit)
+ *    use a different layout and are unaffected. Styles in
  *    labki-tweeki.css section "Page actions relocation".
  *
  * 5. Timestamp localization. Convert SMW-rendered UTC ISO timestamps
@@ -219,9 +223,52 @@
 		return null;
 	}
 
+	// VisualEditor renders its own Save button at the top-right of the
+	// content card — exactly where we'd anchor `.page-actions`. Two
+	// activation paths to detect:
+	//   1. Direct nav with `?veaction=edit` in the URL — we skip the
+	//      relocation entirely so nothing lands in VE's slot.
+	//   2. Inline activation from a click — VE fires the public
+	//      `mw.hook('ve.activationComplete')` event. We listen for it
+	//      and toggle our own `labki-ve-active` class on <html>, which
+	//      a CSS rule uses to hide the already-relocated cluster.
+	// We deliberately use the mw.hook API instead of guessing at VE's
+	// internal `ve-activated` / `ve-active` body classes — those have
+	// shifted across VE versions and skins, so class-sniffing breaks
+	// silently while the hook contract is stable.
+	function isVisualEditorOnInitialLoad() {
+		try {
+			var params = new URLSearchParams( window.location.search );
+			return params.get( 'veaction' ) === 'edit';
+		} catch ( e ) {
+			return false;
+		}
+	}
+
+	function setVisualEditorActive( active ) {
+		document.documentElement.classList.toggle( 'labki-ve-active', !!active );
+	}
+
+	function watchVisualEditor() {
+		if ( isVisualEditorOnInitialLoad() ) {
+			setVisualEditorActive( true );
+		}
+		if ( typeof mw !== 'undefined' && typeof mw.hook === 'function' ) {
+			mw.hook( 've.activationComplete' ).add( function () {
+				setVisualEditorActive( true );
+			} );
+			mw.hook( 've.deactivationComplete' ).add( function () {
+				setVisualEditorActive( false );
+			} );
+		}
+	}
+
 	function relocatePageActions() {
 		var sidebar = document.getElementById( 'sidebar-right' );
 		if ( !sidebar ) {
+			return;
+		}
+		if ( isVisualEditorOnInitialLoad() ) {
 			return;
 		}
 		var group = findActionGroup( sidebar );
@@ -389,6 +436,7 @@
 		relocatePageActions();
 		installSidebarToggle();
 		localizeTimestamps();
+		watchVisualEditor();
 
 		if ( !mw.user.isAnon() ) {
 			refreshBadges();

--- a/resources/styles/labki-tweeki.css
+++ b/resources/styles/labki-tweeki.css
@@ -451,6 +451,25 @@ html.sidebar-collapsed .sidebar-toggle svg {
 	padding-right: 110px;
 }
 
+/* Hide the relocated cluster while VisualEditor is active — VE's own
+   Save button claims the same top-right slot. relocatePageActions()
+   skips when VE is reached via `?veaction=edit`; this rule covers
+   inline activation, where labki-tweeki.js listens for the public
+   `mw.hook('ve.activationComplete')` event and toggles
+   `labki-ve-active` on <html>. We use our own class (rather than
+   VE's internal `ve-activated` / `ve-active`) because those move
+   between <html> and <body> across VE versions and skins. The
+   #firstHeading rule restores the heading's width once .page-actions
+   is gone, so the title doesn't appear indented under VE. */
+html.labki-ve-active .page-actions {
+	display: none;
+}
+
+html.labki-ve-active .mw-body #firstHeading,
+html.labki-ve-active #content #firstHeading {
+	padding-right: 0;
+}
+
 @media (max-width: 600px) {
 	.page-actions {
 		position: static !important;

--- a/resources/styles/labki-tweeki.css
+++ b/resources/styles/labki-tweeki.css
@@ -20,6 +20,15 @@
 	--labki-heading:       #1a3a5c;
 	--labki-warning:       #f0ad4e;
 	--labki-danger:        #d9534f;
+
+	/* Surface and elevation tokens. Schema bundles (TemplateStyles)
+	   and per-wiki CSS compose against these so cards, sideboxes,
+	   etc. flip cleanly with [data-bs-theme="dark"] without needing
+	   their own dark-mode logic. */
+	--labki-surface:       #ffffff;
+	--labki-shadow-sm:     0 1px 4px rgba(0, 0, 0, 0.07);
+	--labki-shadow-md:     0 4px 16px rgba(0, 59, 92, 0.12);
+	--labki-radius:        8px;
 }
 
 /* Dark theme palette. Bootstrap 5.3 handles most components via
@@ -38,6 +47,11 @@
 	--labki-heading:       #b8d4f0;
 	--labki-warning:       #f0ad4e;
 	--labki-danger:        #e25d59;
+
+	--labki-surface:       #161b22;
+	--labki-shadow-sm:     0 1px 4px rgba(0, 0, 0, 0.50);
+	--labki-shadow-md:     0 4px 16px rgba(0, 0, 0, 0.60);
+	/* --labki-radius shared with light mode. */
 }
 
 [data-bs-theme="dark"] body {
@@ -46,7 +60,7 @@
 }
 
 [data-bs-theme="dark"] #content {
-	background-color: #161b22;
+	background-color: var(--labki-surface);
 	color: var(--labki-text);
 }
 
@@ -262,4 +276,163 @@ footer.footer a,
 .toc {
 	background-color: var(--labki-bg-subtle);
 	border: 1px solid var(--labki-border);
+}
+
+/* === Right sidebar collapse drawer ===
+   Tweeki renders #sidebar-right inside a Bootstrap row alongside
+   #maincontentwrapper. labki-tweeki.js injects a `.sidebar-toggle`
+   button anchored to the viewport's left edge; clicking it toggles
+   `body.sidebar-collapsed`, which animates the sidebar shut and
+   gives the content row full width.
+
+   The sidebar is also visually relocated to the LEFT of content via
+   flex `order` — this matches the reading-order convention of
+   contents-rail-on-left. */
+.row > #sidebar-right {
+	order: -1;
+}
+
+.row > #sidebar-left {
+	order: -2;
+}
+
+.row > #maincontentwrapper {
+	order: 0;
+}
+
+#sidebar-right {
+	transition: flex-basis 0.25s ease, max-width 0.25s ease,
+	            padding 0.25s ease, margin 0.25s ease, opacity 0.2s ease;
+	overflow: hidden;
+}
+
+#maincontentwrapper {
+	transition: flex-basis 0.25s ease, max-width 0.25s ease;
+}
+
+body.sidebar-collapsed #sidebar-right {
+	flex: 0 0 0 !important;
+	max-width: 0 !important;
+	padding-left: 0 !important;
+	padding-right: 0 !important;
+	margin-left: 0 !important;
+	margin-right: 0 !important;
+	opacity: 0;
+}
+
+body.sidebar-collapsed #maincontentwrapper {
+	flex: 0 0 100% !important;
+	max-width: 100% !important;
+}
+
+/* Drawer pull-tab attached to the viewport's left edge, vertically
+   centered. Stays anchored regardless of sidebar state; the chevron
+   rotates to indicate direction. */
+.sidebar-toggle {
+	position: fixed;
+	top: 50%;
+	left: 0;
+	transform: translateY(-50%);
+	z-index: 1000;
+
+	width: 24px;
+	height: 64px;
+
+	border: 1px solid var(--labki-border);
+	border-left: none;
+	border-radius: 0 10px 10px 0;
+
+	background: linear-gradient(90deg, var(--labki-surface) 0%, var(--labki-bg-subtle) 100%);
+	color: var(--labki-primary);
+
+	cursor: pointer;
+	padding: 0;
+
+	box-shadow: var(--labki-shadow-sm);
+
+	display: flex;
+	align-items: center;
+	justify-content: center;
+
+	transition: transform 0.2s ease,
+	            background 0.18s ease,
+	            color 0.18s ease,
+	            box-shadow 0.18s ease;
+}
+
+.sidebar-toggle:hover {
+	/* Nudge the tab to the right on hover — looks like it's being
+	   pulled out from the edge. translateY(-50%) preserved for centering. */
+	transform: translate(3px, -50%);
+	color: var(--labki-accent);
+	box-shadow: var(--labki-shadow-md);
+}
+
+.sidebar-toggle:active {
+	transform: translate(1px, -50%);
+}
+
+.sidebar-toggle:focus-visible {
+	outline: none;
+	box-shadow: 0 0 0 3px rgba(61, 122, 181, 0.30),
+	            var(--labki-shadow-sm);
+}
+
+.sidebar-toggle svg {
+	width: 13px;
+	height: 13px;
+	pointer-events: none;
+	transition: transform 0.25s ease;
+}
+
+/* Open: chevron points left ("close me").
+   Collapsed: chevron points right ("pull me out"). */
+body.sidebar-collapsed .sidebar-toggle svg {
+	transform: rotate(180deg);
+}
+
+/* Hide the toggle on narrow viewports where the sidebar naturally
+   stacks below the content. */
+@media (max-width: 767px) {
+	.sidebar-toggle {
+		display: none;
+	}
+}
+
+/* === Page actions relocation ===
+   labki-tweeki.js lifts the page-action button cluster (Edit,
+   History, etc.) out of #sidebar-right and re-anchors it to a
+   stable spot at the top-right of the content card. This keeps the
+   button visible regardless of sidebar collapse or window width. */
+.mw-body,
+#content {
+	position: relative !important; /* anchor for absolute-positioned .page-actions */
+}
+
+.page-actions {
+	position: absolute !important;
+	top: 16px;
+	right: 20px;
+	z-index: 10;
+	margin: 0;
+}
+
+/* Reserve room so the heading text doesn't underflow the action button. */
+.mw-body #firstHeading,
+#content #firstHeading {
+	padding-right: 110px;
+}
+
+@media (max-width: 600px) {
+	.page-actions {
+		position: static !important;
+		margin: 0 0 14px;
+		display: flex;
+		justify-content: flex-end;
+	}
+
+	.mw-body #firstHeading,
+	#content #firstHeading {
+		padding-right: 0;
+	}
 }

--- a/resources/styles/labki-tweeki.css
+++ b/resources/styles/labki-tweeki.css
@@ -417,6 +417,24 @@ body.sidebar-collapsed .sidebar-toggle svg {
 	margin: 0;
 }
 
+/* Pre-relocate, the action cluster paints inside #sidebar-right. The flex
+   `order: -1` we apply below puts the sidebar visually on the LEFT, so
+   without this rule users see the cluster flash at top-left for one frame
+   before JS moves it to the .page-actions anchor at top-right. Hide the
+   server-rendered location via visibility so layout still reserves the
+   space (no jump). The keyframe is a JS-broken safety fallback: if init
+   hasn't relocated within 1s, reveal in place so the affordance is never
+   permanently lost. Once relocated, the cluster is inside .page-actions
+   (outside #sidebar-right) and this selector no longer matches. */
+@keyframes labki-page-actions-reveal {
+	to { visibility: visible; }
+}
+
+#sidebar-right :is(#p-cactions, #p-views, .tweeki-cactions) {
+	visibility: hidden;
+	animation: labki-page-actions-reveal 0s 1s forwards;
+}
+
 /* Reserve room so the heading text doesn't underflow the action button. */
 .mw-body #firstHeading,
 #content #firstHeading {

--- a/resources/styles/labki-tweeki.css
+++ b/resources/styles/labki-tweeki.css
@@ -282,8 +282,12 @@ footer.footer a,
    Tweeki renders #sidebar-right inside a Bootstrap row alongside
    #maincontentwrapper. labki-tweeki.js injects a `.sidebar-toggle`
    button anchored to the viewport's left edge; clicking it toggles
-   `body.sidebar-collapsed`, which animates the sidebar shut and
-   gives the content row full width.
+   `html.sidebar-collapsed`, which animates the sidebar shut and
+   gives the content row full width. The class is set on <html>
+   (not <body>) so the inline <head> bootstrap script in
+   skins.platform.php can apply it from localStorage BEFORE paint —
+   without that, users with a previously-collapsed sidebar would see
+   it render expanded and then animate shut on every page load.
 
    The sidebar is also visually relocated to the LEFT of content via
    flex `order` — this matches the reading-order convention of
@@ -310,7 +314,7 @@ footer.footer a,
 	transition: flex-basis 0.25s ease, max-width 0.25s ease;
 }
 
-body.sidebar-collapsed #sidebar-right {
+html.sidebar-collapsed #sidebar-right {
 	flex: 0 0 0 !important;
 	max-width: 0 !important;
 	padding-left: 0 !important;
@@ -320,7 +324,7 @@ body.sidebar-collapsed #sidebar-right {
 	opacity: 0;
 }
 
-body.sidebar-collapsed #maincontentwrapper {
+html.sidebar-collapsed #maincontentwrapper {
 	flex: 0 0 100% !important;
 	max-width: 100% !important;
 }
@@ -387,7 +391,7 @@ body.sidebar-collapsed #maincontentwrapper {
 
 /* Open: chevron points left ("close me").
    Collapsed: chevron points right ("pull me out"). */
-body.sidebar-collapsed .sidebar-toggle svg {
+html.sidebar-collapsed .sidebar-toggle svg {
 	transform: rotate(180deg);
 }
 
@@ -430,7 +434,13 @@ body.sidebar-collapsed .sidebar-toggle svg {
 	to { visibility: visible; }
 }
 
-#sidebar-right :is(#p-cactions, #p-views, .tweeki-cactions) {
+/* `.btn-group` covers Tweeki's standard EDIT-EXT wrapper (Tweeki's
+   tweeki-sidebar-right-wrapperclass message defaults to "btn-group
+   mb-1"). The MediaWiki-standard #p-cactions / #p-views IDs cover
+   non-Tweeki layouts. We deliberately don't include `.dropdown` —
+   Tweeki's TOC also carries that class, and hiding it would blank
+   the scroll-spy panel. */
+#sidebar-right :is(#p-cactions, #p-views, .tweeki-cactions, .btn-group) {
 	visibility: hidden;
 	animation: labki-page-actions-reveal 0s 1s forwards;
 }


### PR DESCRIPTION
## Summary
- Migrates utilities every labki wiki was duplicating into `MediaWiki:Common.css/js` to the platform Tweeki resource modules (`labki-tweeki.css` / `labki-tweeki.js`). Five additions:
  - **Surface and elevation tokens** (`--labki-surface`, `--labki-shadow-sm`, `--labki-shadow-md`, `--labki-radius`) in `:root` and `[data-bs-theme="dark"]` — schema bundles and per-wiki CSS compose against these and flip cleanly with the existing Bootstrap theme attribute.
  - **Right sidebar collapse drawer**: a viewport-anchored pull-tab button toggles `body.sidebar-collapsed`; state persists in `localStorage["labki.sidebarCollapsed"]`. Skipped on pages where `#sidebar-right` ends up empty after page-actions relocation.
  - **Page-actions relocation**: lifts the Edit / History action cluster out of `#sidebar-right` and re-anchors it at the top-right of the content card so it survives sidebar collapse and narrow viewports.
  - **`<html>` login-state classes** (`is-anon` / `is-logged-in`) so per-wiki CSS can render login-conditional UI without a DOM round-trip.
  - **Generalized timestamp localizer**: SMW-rendered UTC ISO timestamps in `<time datetime="...">` elements (preferred, semantic) and bare ISO strings inside wikitext table cells (legacy SMW backstop) are converted to the viewer's locale via `toLocaleString()`. Drops the prior page-name restriction, idempotent via `data-localized` marker.

## Out of scope (intentional)
Schema-coupled UI (status sidebox, document masthead) and content-design primitives (hero, button, card, kpi-card, secondary-nav) are deliberately **not** added here. Those belong in a design-system bundle delivered via TemplateStyles (see PR #50), not in platform infrastructure — different concerns, different cadences, opt-in vs imposed.

## Test plan
- [ ] On a wiki with Tweeki active and a TOC-bearing page, confirm the sidebar pull-tab appears on the left edge of the viewport and toggles `body.sidebar-collapsed` (TOC slides shut, content widens)
- [ ] On a page where the sidebar's only content was page-actions (no TOC, no portals), confirm the pull-tab does **not** install
- [ ] Confirm the Edit/History action cluster renders at the top-right of the content card and stays visible while the sidebar is collapsed
- [ ] Confirm `<html>` carries `is-anon` while logged out and `is-logged-in` after login (devtools)
- [ ] Place `<time datetime="2026-01-01T12:00:00Z">2026-01-01T12:00:00Z</time>` on a test page; confirm the visible text renders in the viewer's local timezone while the `datetime` attribute is preserved
- [ ] Toggle dark mode; confirm `#content` background uses `var(--labki-surface)` and shadows / radius read from the new tokens
- [ ] On viewports < 767px, confirm the pull-tab is hidden; on viewports < 600px, confirm `.page-actions` falls back to inline display above the heading
- [ ] Confirm sidebar-collapse state persists across reloads via `localStorage["labki.sidebarCollapsed"]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)