### PR TITLE
Default the platform skin to Tweeki

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CHANGELOG.md for tracking releases
 - CI badges in README
 
+### Changed
+- Default skin is now Tweeki (was vector-2022). Tweeki is the curated labki experience and carries platform-specific chrome (labki-tweeki.css/js — theme toggle, sidebar drawer, page-actions relocation, login-state classes, LABKI-LOGIN / LABKI-THEME-TOGGLE nav elements). Vector and Citizen remain loaded; users can switch via Special:Preferences. Existing users with a saved skin preference are unaffected.
+
 ## [0.1.0] - 2026-01-13
 
 ### Added

--- a/ci/smoke-test.sh
+++ b/ci/smoke-test.sh
@@ -93,8 +93,8 @@ FILE_EXTS=$(extract FILE_EXTENSIONS)
 EXT_NAMES=$(extract EXTENSIONS)
 
 echo "[smoke-test] Verifying default skin..."
-[ "$DEFAULT_SKIN" = "vector-2022" ] \
-    || fail "default skin is '$DEFAULT_SKIN', expected 'vector-2022'."
+[ "$DEFAULT_SKIN" = "tweeki" ] \
+    || fail "default skin is '$DEFAULT_SKIN', expected 'tweeki'."
 
 echo "[smoke-test] Verifying platform skins..."
 for skin in vector citizen tweeki; do

--- a/mediawiki/skins.platform.php
+++ b/mediawiki/skins.platform.php
@@ -11,15 +11,22 @@ if (!defined('MEDIAWIKI')) {
 
 // --- Skin loads ---
 //
-// Vector ships with MediaWiki and provides both the legacy ('vector') and
-// current ('vector-2022') skins. We default to vector-2022 to match stock
-// MediaWiki and surface standard navigation (sidebar with Special pages,
-// history button, etc.) without any per-skin overrides.
+// Tweeki is the curated labki experience: it carries platform-specific
+// chrome (labki-tweeki.css/js — navbar, footer, theme toggle, sidebar
+// drawer, page-actions relocation, login-state classes, custom nav
+// elements like LABKI-LOGIN and LABKI-THEME-TOGGLE), so anonymous
+// viewers and new accounts land here by default.
+//
+// Vector ships with MediaWiki (legacy 'vector' and current 'vector-2022')
+// and Citizen is loaded too — both stay available for users who prefer a
+// different skin via Special:Preferences. Existing users with a saved
+// skin preference are unaffected; only the anon/new-account default
+// changes here.
 wfLoadSkin('Vector');
 wfLoadSkin('Citizen');
 wfLoadSkin('Tweeki');
 
-$wgDefaultSkin = 'vector-2022';
+$wgDefaultSkin = 'tweeki';
 
 // --- Tweeki customization ---
 //


### PR DESCRIPTION
## Summary
- Switches `\$wgDefaultSkin` from `vector-2022` to `tweeki` so anon viewers and new accounts land on the curated labki experience by default.
- Vector and Citizen remain loaded; users can pick a different skin via `Special:Preferences`. Existing users with a saved skin preference are unaffected — `\$wgDefaultSkin` only governs the anon / new-account first render.

## Why
The platform invests heavily in Tweeki: navbar styling, footer, theme toggle, sidebar drawer, page-actions relocation, login-state HTML classes, custom nav elements (`LABKI-LOGIN`, `LABKI-THEME-TOGGLE`), Echo notification badges, FA icon mapping, anonymous Log in / Request Account buttons. None of that fires on Vector. Defaulting to Tweeki signals that this is the intended labki surface and exposes anon viewers to it.

## Test plan
- [ ] Fresh dev wiki: visit `/wiki/Main_Page` while logged out → renders in Tweeki (dark UCLA-blue navbar, theme toggle visible top-right, anon Log in / Request Account buttons render via `LABKI-LOGIN`)
- [ ] Create a new account → first render is in Tweeki
- [ ] Existing user with saved preference for Vector or Citizen → still gets their saved skin (no regression)
- [ ] `Special:Preferences` → "Appearance" → all three skins still selectable

🤖 Generated with [Claude Code](https://claude.com/claude-code)