### PR TITLE
Bundle LabkiPageFormsInputs

### DIFF
--- a/extensions-git/sources.txt
+++ b/extensions-git/sources.txt
@@ -5,6 +5,7 @@ WikiForum https://gerrit.wikimedia.org/r/mediawiki/extensions/WikiForum.git mast
 ConfirmAccount https://gerrit.wikimedia.org/r/mediawiki/extensions/ConfirmAccount.git REL1_44 extension
 MWAssistant https://github.com/labki-org/MWAssistant.git main extension
 SemanticSchemas https://github.com/labki-org/SemanticSchemas.git feature/dispatcher-bakes-display-schema extension
+LabkiPageFormsInputs https://github.com/labki-org/LabkiPageFormsInputs.git main extension
 FilePermissions https://github.com/labki-org/FilePermissions.git main extension
 Citizen https://github.com/StarCitizenTools/mediawiki-skins-Citizen.git v3.6.0 skin
 Tweeki https://github.com/thaider/Tweeki.git master skin

--- a/mediawiki/extensions.platform.php
+++ b/mediawiki/extensions.platform.php
@@ -31,6 +31,13 @@ wfLoadExtension('Mermaid');
 wfLoadExtension('MsUpload');
 wfLoadExtension('Lockdown');
 
+// PageForms add-on: registers labki-datetime / labki-date / labki-time
+// input types backed by flatpickr. Must load after PageForms (above) so
+// the FormPrinterSetup hook fires correctly. To make it the wiki-wide
+// default for all SMW Date properties, set in LocalSettings.user.php:
+//   $wgSemanticSchemasDatatypeInputOverrides['Date'] = 'labki-datetime';
+wfLoadExtension('LabkiPageFormsInputs');
+
 // --- Bundled MediaWiki Extensions (shipped with MW 1.44) ---
 
 wfLoadExtension('Echo');


### PR DESCRIPTION
## Summary

- Bundles `LabkiPageFormsInputs` (https://github.com/labki-org/LabkiPageFormsInputs) — a PageForms add-on that registers three flatpickr-backed input types: `labki-datetime`, `labki-date`, `labki-time`.
- Cloned at build time via `extensions-git/sources.txt`.
- Loaded via `extensions.platform.php` immediately after `MsUpload`/`Lockdown` in the Git-cloned section, with a comment noting it must load after PageForms (which is loaded earlier in the file).

## Why these inputs

PageForms ships `datepicker` (date only) and `datetimepicker` (forces a time, UTC only). LabkiPageFormsInputs covers date-or-datetime on the same SMW Date property, supports timezones (DST-aware), and stores values in a round-trippable form so re-editing a saved value doesn't silently rewrite the offset.

| Input type        | SMW property type | Saves as |
| ----------------- | ----------------- | --------- |
| `labki-datetime`  | `Date` (`_dat`)   | `YYYY-MM-DD` / `YYYY-MM-DDTHH:MM` / `YYYY-MM-DDTHH:MM:SS±HH:MM` |
| `labki-date`      | `Date` (`_dat`)   | `YYYY-MM-DD` |
| `labki-time`      | `Text` (`_txt`)   | `HH:MM` or `HH:MM <IANA_zone>` |

## SemanticSchemas: deliberately not enabled wiki-wide

This PR does **not** set `$wgSemanticSchemasDatatypeInputOverrides['Date'] = 'labki-datetime'`. After installing this PR every platform-built wiki will:

- Have the three input types **available** via `has_input_type=labki-datetime` etc.
- **Continue using PageForms' built-in `datepicker`** as the default for existing `Date` properties.

To opt in wiki-wide, an admin can add this to their `LocalSettings.user.php`:

```php
$wgSemanticSchemasDatatypeInputOverrides['Date'] = 'labki-datetime';
```

This avoids silently changing the date-input UI on every existing form across every wiki built on this platform.

## Configuration knobs (all optional)

LabkiPageFormsInputs declares four `$wg*` settings — all default-safe, all overridable per-wiki in `LocalSettings.user.php`:

- `$wgLabkiPageFormsInputsTzShortlist` — per-wiki curated TZ dropdown (`'IANA' => 'Display label'`)
- `$wgLabkiPageFormsInputsTime24h` (default `true`) — 24h vs 12h AM/PM display
- `$wgLabkiPageFormsInputsFirstDayOfWeek` (default `1` = Monday) — calendar week start
- `$wgLabkiPageFormsInputsDefaultTz` — fallback IANA zone for users without a `timecorrection` preference

See [USAGE.md](https://github.com/labki-org/LabkiPageFormsInputs/blob/main/USAGE.md) in the upstream repo for the full reference.

## Test plan

- [ ] CI builds the platform image, clones the new extension into `/extensions/`, and loads it.
- [ ] Boot a fresh wiki from the new image; confirm `Special:Version` lists "LabkiPageFormsInputs 0.2.0".
- [ ] Create a `Property:Has start date` with `[[Has type::Date]]` and `[[Has input type::labki-datetime]]`; confirm the form renders the flatpickr widget.
- [ ] Save a value with a timezone; confirm `[[Has start date::2026-09-12T14:30:00-07:00]]` appears in the page wikitext.
- [ ] Re-edit and re-save without picking a new TZ; confirm the offset is preserved.
- [ ] Confirm wikis that don't opt in still see the default `datepicker` on existing Date properties.

🤖 Generated with [Claude Code](https://claude.com/claude-code)