### PR TITLE
Hide sidebar drawer when there's no content to display

### DIFF
--- a/resources/scripts/labki-tweeki.js
+++ b/resources/scripts/labki-tweeki.js
@@ -153,19 +153,35 @@
 	// True when #sidebar-right has rendered content worth collapsing.
 	// Called after relocatePageActions(), so the action cluster has
 	// already been lifted out — what remains is TOC, portals, etc.
-	// Structural check (children.length) rather than textContent: Tweeki
-	// renders the scroll-spy TOC as an empty <div id="tweekiTOC"> that
-	// gets populated client-side AFTER our init runs, so a text-based
-	// check would skip the toggle on every page with a yet-to-be-filled
-	// TOC. If the sidebar's only content was the action cluster,
-	// relocatePageActions has emptied it and we correctly skip.
+	// textContent is the truthful proxy: meaningful sidebar entries
+	// (TOC links, portal items) all carry visible text. children.length
+	// is misleading because Tweeki injects an empty <div id="tweekiTOC">
+	// stub that's always present even on heading-less pages.
 	function sidebarHasContent( sidebar ) {
-		return sidebar.children.length > 0;
+		return sidebar.textContent.trim() !== '';
+	}
+
+	// Suppress the 250ms shrink animation on the initial empty paint —
+	// without this, users on heading-less pages would see the sidebar
+	// briefly render full-width, then collapse, after our script runs.
+	function applySidebarEmpty( html, empty ) {
+		if ( empty ) {
+			html.classList.add( 'sidebar-no-transition', 'sidebar-empty' );
+			// Force a reflow so the no-transition rule applies before the
+			// next paint, then drop the suppressor for any later changes.
+			// eslint-disable-next-line no-unused-expressions
+			document.body.offsetWidth;
+			requestAnimationFrame( function () {
+				html.classList.remove( 'sidebar-no-transition' );
+			} );
+		} else {
+			html.classList.remove( 'sidebar-empty' );
+		}
 	}
 
 	function installSidebarToggle() {
 		var sidebar = document.getElementById( 'sidebar-right' );
-		if ( !sidebar || !sidebarHasContent( sidebar ) ) {
+		if ( !sidebar ) {
 			return;
 		}
 
@@ -179,24 +195,58 @@
 			html.classList.add( 'sidebar-collapsed' );
 		}
 
-		var btn = document.createElement( 'button' );
-		btn.type = 'button';
-		btn.className = 'sidebar-toggle';
-		btn.setAttribute( 'aria-label', 'Toggle side panel' );
-		btn.setAttribute( 'title', 'Toggle side panel' );
-		btn.setAttribute(
-			'aria-expanded',
-			html.classList.contains( 'sidebar-collapsed' ) ? 'false' : 'true'
-		);
-		btn.appendChild( buildSidebarChevron() );
+		var installed = false;
+		function ensureButton() {
+			if ( installed ) {
+				return;
+			}
+			installed = true;
+			applySidebarEmpty( html, false );
 
-		btn.addEventListener( 'click', function () {
-			var collapsed = html.classList.toggle( 'sidebar-collapsed' );
-			btn.setAttribute( 'aria-expanded', collapsed ? 'false' : 'true' );
-			writeSidebarCollapsed( collapsed );
+			var btn = document.createElement( 'button' );
+			btn.type = 'button';
+			btn.className = 'sidebar-toggle';
+			btn.setAttribute( 'aria-label', 'Toggle side panel' );
+			btn.setAttribute( 'title', 'Toggle side panel' );
+			btn.setAttribute(
+				'aria-expanded',
+				html.classList.contains( 'sidebar-collapsed' ) ? 'false' : 'true'
+			);
+			btn.appendChild( buildSidebarChevron() );
+
+			btn.addEventListener( 'click', function () {
+				var collapsed = html.classList.toggle( 'sidebar-collapsed' );
+				btn.setAttribute( 'aria-expanded', collapsed ? 'false' : 'true' );
+				writeSidebarCollapsed( collapsed );
+			} );
+
+			document.body.appendChild( btn );
+		}
+
+		if ( sidebarHasContent( sidebar ) ) {
+			ensureButton();
+			return;
+		}
+
+		// No content yet — Tweeki's scroll-spy TOC populates client-side
+		// after this script runs. Hide the empty panel and watch for
+		// content to arrive; if it does, reveal the panel and install
+		// the toggle. If it doesn't, the panel stays hidden.
+		applySidebarEmpty( html, true );
+		if ( typeof MutationObserver !== 'function' ) {
+			return;
+		}
+		var observer = new MutationObserver( function () {
+			if ( sidebarHasContent( sidebar ) ) {
+				observer.disconnect();
+				ensureButton();
+			}
 		} );
-
-		document.body.appendChild( btn );
+		observer.observe( sidebar, {
+			childList:     true,
+			subtree:       true,
+			characterData: true
+		} );
 	}
 
 	// === Page actions relocation ================================

--- a/resources/scripts/labki-tweeki.js
+++ b/resources/scripts/labki-tweeki.js
@@ -161,22 +161,17 @@
 		return sidebar.textContent.trim() !== '';
 	}
 
-	// Suppress the 250ms shrink animation on the initial empty paint —
-	// without this, users on heading-less pages would see the sidebar
-	// briefly render full-width, then collapse, after our script runs.
-	function applySidebarEmpty( html, empty ) {
-		if ( empty ) {
-			html.classList.add( 'sidebar-no-transition', 'sidebar-empty' );
-			// Force a reflow so the no-transition rule applies before the
-			// next paint, then drop the suppressor for any later changes.
-			// eslint-disable-next-line no-unused-expressions
-			document.body.offsetWidth;
-			requestAnimationFrame( function () {
-				html.classList.remove( 'sidebar-no-transition' );
-			} );
-		} else {
-			html.classList.remove( 'sidebar-empty' );
-		}
+	// Hide the sidebar via .sidebar-empty without animating from full
+	// width to zero on the initial paint. The forced reflow snapshots
+	// the no-transition computed state so dropping the class on the
+	// next frame doesn't trigger the default transition between frames.
+	function hideEmptySidebar( html ) {
+		html.classList.add( 'sidebar-no-transition', 'sidebar-empty' );
+		// eslint-disable-next-line no-unused-expressions
+		document.body.offsetWidth;
+		requestAnimationFrame( function () {
+			html.classList.remove( 'sidebar-no-transition' );
+		} );
 	}
 
 	function installSidebarToggle() {
@@ -195,13 +190,8 @@
 			html.classList.add( 'sidebar-collapsed' );
 		}
 
-		var installed = false;
-		function ensureButton() {
-			if ( installed ) {
-				return;
-			}
-			installed = true;
-			applySidebarEmpty( html, false );
+		function installButton() {
+			html.classList.remove( 'sidebar-empty' );
 
 			var btn = document.createElement( 'button' );
 			btn.type = 'button';
@@ -224,7 +214,7 @@
 		}
 
 		if ( sidebarHasContent( sidebar ) ) {
-			ensureButton();
+			installButton();
 			return;
 		}
 
@@ -232,21 +222,17 @@
 		// after this script runs. Hide the empty panel and watch for
 		// content to arrive; if it does, reveal the panel and install
 		// the toggle. If it doesn't, the panel stays hidden.
-		applySidebarEmpty( html, true );
+		hideEmptySidebar( html );
 		if ( typeof MutationObserver !== 'function' ) {
 			return;
 		}
 		var observer = new MutationObserver( function () {
 			if ( sidebarHasContent( sidebar ) ) {
 				observer.disconnect();
-				ensureButton();
+				installButton();
 			}
 		} );
-		observer.observe( sidebar, {
-			childList:     true,
-			subtree:       true,
-			characterData: true
-		} );
+		observer.observe( sidebar, { childList: true, subtree: true } );
 	}
 
 	// === Page actions relocation ================================

--- a/resources/styles/labki-tweeki.css
+++ b/resources/styles/labki-tweeki.css
@@ -314,7 +314,16 @@ footer.footer a,
 	transition: flex-basis 0.25s ease, max-width 0.25s ease;
 }
 
-html.sidebar-collapsed #sidebar-right {
+/* Two paths to a hidden sidebar:
+   * .sidebar-collapsed — user-toggled via the pull-tab; persisted in
+     localStorage; chevron rotates to indicate state.
+   * .sidebar-empty — script-detected when #sidebar-right has no
+     rendered content (e.g., heading-less page where Tweeki's TOC
+     never populates); no toggle is installed in this case.
+   .sidebar-no-transition is a one-frame suppressor used by the JS to
+   apply .sidebar-empty without animating from full width to zero. */
+html.sidebar-collapsed #sidebar-right,
+html.sidebar-empty #sidebar-right {
 	flex: 0 0 0 !important;
 	max-width: 0 !important;
 	padding-left: 0 !important;
@@ -324,9 +333,15 @@ html.sidebar-collapsed #sidebar-right {
 	opacity: 0;
 }
 
-html.sidebar-collapsed #maincontentwrapper {
+html.sidebar-collapsed #maincontentwrapper,
+html.sidebar-empty #maincontentwrapper {
 	flex: 0 0 100% !important;
 	max-width: 100% !important;
+}
+
+html.sidebar-no-transition #sidebar-right,
+html.sidebar-no-transition #maincontentwrapper {
+	transition: none !important;
 }
 
 /* Drawer pull-tab attached to the viewport's left edge, vertically


### PR DESCRIPTION
## Summary
- The collapse toggle gate (`sidebarHasContent`) was using `children.length > 0`, but Tweeki always renders an empty `<div id="tweekiTOC">` server-side — so the gate was effectively never closed and the toggle appeared next to visually-empty sidebars on heading-less pages (e.g. `https://miniscope.org/wiki/Miniscopev4`).
- Switch the check to `textContent`, and when the sidebar is initially empty, defer the install via `MutationObserver` so the toggle still appears once Tweeki populates the TOC client-side. If no content ever materializes, no toggle is installed.
- Mirror the existing `sidebar-collapsed` CSS via a new `sidebar-empty` class so the empty panel itself disappears alongside the toggle. A one-frame `sidebar-no-transition` suppressor avoids the panel briefly animating from full width to zero on the initial paint.

## Test plan
- [ ] `Main_Page?useskin=tweeki` (has headings): sidebar visible, toggle present, click collapses/expands and persists across reloads.
- [ ] Heading-less page (e.g. a non-existent title or page with body text only): no sidebar, no toggle.
- [ ] User who had the sidebar collapsed in localStorage still sees it collapsed on a content page (preference preserved).
- [ ] No visible flash of the sidebar shrinking on first paint of a heading-less page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)