### PR TITLE
Polish Tweeki theme defaults, sidebar empty-state, and dark contrast

### DIFF
--- a/mediawiki/skins.platform.php
+++ b/mediawiki/skins.platform.php
@@ -200,31 +200,77 @@ $wgHooks['SkinTemplateNavigation::Universal'][] = static function ( $sktemplate,
     }
 };
 
-// Inline <head> bootstrap that applies persisted UI state synchronously
-// before paint. Two pieces of state, both keyed in localStorage and
-// mirrored on <html>:
+// Inline <head> bootstrap that applies UI state synchronously before
+// paint. Three pieces of state, all mirrored on <html>:
 //
-//   * Theme (data-bs-theme) — the actual toggle is in labki-tweeki.js;
-//     this just avoids a flash of light content for users with dark
-//     preference while ResourceLoader catches up.
-//   * Sidebar collapse state (html.sidebar-collapsed) — without this,
-//     users with a previously-collapsed sidebar would see it render
-//     expanded, then animate shut once labki-tweeki.js runs. Setting
-//     the class on <html> (not <body>) is what lets us do this in a
-//     head script — <body> doesn't exist yet at this point.
+//   * Theme (data-bs-theme) — pulled from localStorage. Default is
+//     light; we deliberately ignore `prefers-color-scheme` so first-
+//     visit appearance is a single canonical look regardless of OS.
+//   * Sidebar collapse state (html.sidebar-collapsed) — pulled from
+//     localStorage. Without this, users with a previously-collapsed
+//     sidebar would see it render expanded and animate shut once
+//     labki-tweeki.js runs.
+//   * Sidebar emptiness (html.sidebar-empty) — server-detected via
+//     the parser's TOC data. Tweeki's right sidebar carries the
+//     scroll-spy TOC plus the action cluster; labki-tweeki.js lifts
+//     the action cluster out, leaving only the TOC. When the page
+//     produces no headings the TOC stays empty and the panel renders
+//     with no content. Pre-applying `sidebar-empty` here hides the
+//     panel before first paint and eliminates the visible "expanded
+//     then collapsed" jump on heading-less pages (Main_Page being
+//     the most common).
+//
+// Setting the class on <html> (not <body>) is what lets us do this
+// in a head script — <body> doesn't exist yet at this point.
 $wgHooks['BeforePageDisplay'][] = static function ( $out, $skin ) {
     if ( strtolower( $skin->getSkinName() ) !== 'tweeki' ) {
         return;
     }
+
+    // TOC-empty detection. We pre-apply `sidebar-empty` when we
+    // expect the right-sidebar TOC to render empty so the panel is
+    // hidden before first paint and there's no expanded→collapsed
+    // jump on heading-less pages.
+    //
+    // Threshold: MediaWiki only renders a TOC for pages with at
+    // least 4 sections (controlled by `__NOTOC__` / `__FORCETOC__`
+    // / `__TOC__` magic words and core's count check). With 1-3
+    // sections, getTOCData() returns sections data but core skips
+    // rendering — Tweeki's scroll-spy then has nothing to copy and
+    // #tweekiTOC stays empty. Treating <4 sections as empty
+    // matches reality. Edge case: forced `__TOC__` on a 1-section
+    // page renders a TOC; we'd start that page collapsed and the
+    // JS would silently reveal — a one-frame snap is acceptable.
+    //
+    // Null TOCData (no parser output, e.g., special pages) is also
+    // treated as empty.
+    $tocData = $out->getTOCData();
+    $sectionCount = $tocData ? count( $tocData->getSections() ) : 0;
+    $sidebarLikelyEmpty = ( $sectionCount < 4 );
+
+    // Per-URL emptiness cache as a self-correcting backstop. Server-
+    // side TOC count is a heuristic — Tweeki's scroll-spy can wind
+    // up empty even when the page has 1-3 headings, and full when
+    // a portal injects content we didn't predict. labki-tweeki.js
+    // writes the post-paint truth to localStorage keyed by path,
+    // and this script reads it next visit. The cache wins over the
+    // server hint when present, so any first-visit miss self-heals
+    // on the second visit.
+    $serverEmpty = $sidebarLikelyEmpty ? 'true' : 'false';
+
     $out->addHeadItem(
         'labki-ui-state-init',
         "<script>(function(){try{"
-        . "var t=localStorage.getItem('labki-theme');"
-        . "if(!t&&window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches){t='dark';}"
-        . "if(t==='dark'){document.documentElement.setAttribute('data-bs-theme','dark');}"
+        . "if(localStorage.getItem('labki-theme')==='dark'){"
+        . "document.documentElement.setAttribute('data-bs-theme','dark');"
+        . "}"
         . "if(localStorage.getItem('labki.sidebarCollapsed')==='true'){"
         . "document.documentElement.classList.add('sidebar-collapsed');"
         . "}"
+        . "var apply=$serverEmpty,key=window.location.pathname+window.location.search;"
+        . "var raw=localStorage.getItem('labki.sidebarEmptyCache');"
+        . "if(raw){try{var m=JSON.parse(raw);if(m&&key in m){apply=m[key]==='empty';}}catch(e){}}"
+        . "if(apply){document.documentElement.classList.add('sidebar-empty');}"
         . "}catch(e){}})();</script>"
     );
 };

--- a/resources/scripts/labki-tweeki.js
+++ b/resources/scripts/labki-tweeki.js
@@ -5,8 +5,10 @@
  *
  * 1. Light/dark theme toggle. Bootstrap 5.3 styles components based
  *    on `<html data-bs-theme>`; we set it from localStorage on first
- *    paint, then swap on click of the navbar toggle button. Falls
- *    back to `prefers-color-scheme` when no preference is stored.
+ *    paint, then swap on click of the navbar toggle button. Defaults
+ *    to light when no preference is stored — we deliberately ignore
+ *    `prefers-color-scheme` so the wiki has a single canonical first-
+ *    visit appearance regardless of the visitor's OS theme.
  *
  * 2. Tag <html> with `is-anon` or `is-logged-in` so per-wiki CSS can
  *    render login-conditional UI without a DOM round-trip.
@@ -72,14 +74,7 @@
 	}
 
 	function preferredTheme() {
-		var stored = readStoredTheme();
-		if ( stored === 'light' || stored === 'dark' ) {
-			return stored;
-		}
-		if ( window.matchMedia && window.matchMedia( '(prefers-color-scheme: dark)' ).matches ) {
-			return 'dark';
-		}
-		return 'light';
+		return readStoredTheme() === 'dark' ? 'dark' : 'light';
 	}
 
 	function applyTheme( theme ) {
@@ -161,12 +156,55 @@
 		return sidebar.textContent.trim() !== '';
 	}
 
-	// Hide the sidebar via .sidebar-empty without animating from full
-	// width to zero on the initial paint. The forced reflow snapshots
-	// the no-transition computed state so dropping the class on the
-	// next frame doesn't trigger the default transition between frames.
-	function hideEmptySidebar( html ) {
-		html.classList.add( 'sidebar-no-transition', 'sidebar-empty' );
+	// Per-URL emptiness cache. The inline <head> bootstrap reads this
+	// to decide whether to pre-apply `sidebar-empty` before paint —
+	// it's a self-correcting backstop for the server-side TOC count,
+	// which can be wrong when Tweeki's scroll-spy doesn't render the
+	// TOC despite 4+ sections, or when a portal we didn't predict
+	// pushes content into a sidebar the server thought was empty.
+	// First visit may flash; subsequent visits don't.
+	var SIDEBAR_EMPTY_CACHE_KEY = 'labki.sidebarEmptyCache';
+
+	function writeSidebarEmptyCache( isEmpty ) {
+		try {
+			var key = window.location.pathname + window.location.search;
+			var raw = localStorage.getItem( SIDEBAR_EMPTY_CACHE_KEY );
+			var map = {};
+			if ( raw ) {
+				try {
+					var parsed = JSON.parse( raw );
+					if ( parsed && typeof parsed === 'object' ) {
+						map = parsed;
+					}
+				} catch ( e ) {
+					// Corrupt cache; reset.
+				}
+			}
+			map[ key ] = isEmpty ? 'empty' : 'filled';
+			localStorage.setItem( SIDEBAR_EMPTY_CACHE_KEY, JSON.stringify( map ) );
+		} catch ( e ) {
+			// localStorage unavailable; non-fatal.
+		}
+	}
+
+	// Toggle .sidebar-empty without animating between full and zero
+	// width. Used for both directions:
+	//   * hide — the sidebar painted visible but turned out empty
+	//     (server didn't pre-apply, JS confirmed empty post-paint).
+	//   * reveal — the server pre-applied `sidebar-empty` but content
+	//     materialized (e.g., a portal entry we didn't predict, or
+	//     Tweeki's TOC populated late on a heading-bearing page that
+	//     somehow slipped past the server check).
+	// The forced reflow snapshots the no-transition computed state so
+	// dropping the class on the next frame doesn't trigger the default
+	// transition between frames. No-op when the target state is already
+	// in effect, so callers can invoke unconditionally.
+	function setSidebarEmpty( html, empty ) {
+		if ( html.classList.contains( 'sidebar-empty' ) === empty ) {
+			return;
+		}
+		html.classList.add( 'sidebar-no-transition' );
+		html.classList.toggle( 'sidebar-empty', empty );
 		// eslint-disable-next-line no-unused-expressions
 		document.body.offsetWidth;
 		requestAnimationFrame( function () {
@@ -180,8 +218,8 @@
 			return;
 		}
 
-		// The class lives on <html> rather than <body> so the inline
-		// <head> bootstrap script in skins.platform.php can apply it
+		// The collapsed class lives on <html> rather than <body> so the
+		// inline <head> bootstrap in skins.platform.php can apply it
 		// before paint. By the time we run, that script has likely
 		// already set the class — classList.add is idempotent, so the
 		// guard below is just for browsers without localStorage support.
@@ -191,8 +229,6 @@
 		}
 
 		function installButton() {
-			html.classList.remove( 'sidebar-empty' );
-
 			var btn = document.createElement( 'button' );
 			btn.type = 'button';
 			btn.className = 'sidebar-toggle';
@@ -214,21 +250,33 @@
 		}
 
 		if ( sidebarHasContent( sidebar ) ) {
+			setSidebarEmpty( html, false );
+			writeSidebarEmptyCache( false );
 			installButton();
 			return;
 		}
 
-		// No content yet — Tweeki's scroll-spy TOC populates client-side
-		// after this script runs. Hide the empty panel and watch for
-		// content to arrive; if it does, reveal the panel and install
-		// the toggle. If it doesn't, the panel stays hidden.
-		hideEmptySidebar( html );
+		// No content yet. Two paths converge here:
+		//   * Inline bootstrap pre-applied `sidebar-empty` (server
+		//     TOC count or cached prior visit said "empty") — class
+		//     is already on <html>, so this is a no-op.
+		//   * Bootstrap didn't pre-apply — apply now. The reflow
+		//     trick suppresses the visible-to-hidden animation.
+		// Then watch for surprise content (Tweeki's scroll-spy TOC
+		// populates client-side after this script runs, and other
+		// extensions can inject sidebar entries). If it arrives,
+		// reveal silently, update the cache so the next visit
+		// doesn't pre-hide, and install the toggle.
+		setSidebarEmpty( html, true );
+		writeSidebarEmptyCache( true );
 		if ( typeof MutationObserver !== 'function' ) {
 			return;
 		}
 		var observer = new MutationObserver( function () {
 			if ( sidebarHasContent( sidebar ) ) {
 				observer.disconnect();
+				setSidebarEmpty( html, false );
+				writeSidebarEmptyCache( false );
 				installButton();
 			}
 		} );
@@ -394,18 +442,38 @@
 		message: 'pt-notifications-notice'
 	};
 
+	// Locate the user dropdown's toggle so we can stamp the aggregate
+	// unread badge on it. We anchor on a known PERSONAL-menu item id
+	// (pt-notifications-* and pt-userpage live inside the user
+	// dropdown) and walk up to the enclosing Bootstrap `.dropdown`,
+	// rather than picking the first `.dropdown-toggle` in the navbar.
+	// The earlier "first toggle in .nav/.navbar-nav" heuristic matched
+	// any dropdown in MediaWiki:Tweeki-navbar-left too, so the badge
+	// landed on the leftmost navbar-left entry instead of the user.
 	function findUserToggle() {
-		var navbar = document.getElementById( 'mw-navigation' );
-		if ( !navbar ) {
-			return null;
-		}
-		var toggles = navbar.querySelectorAll( '.dropdown-toggle' );
-		for ( var i = 0; i < toggles.length; i++ ) {
-			if ( toggles[ i ].closest( '.navbar-right, .ms-auto, .nav, .navbar-nav' ) ) {
-				return toggles[ i ];
+		var anchorIds = [
+			'pt-notifications-alert',
+			'pt-notifications-notice',
+			'pt-userpage',
+			'pt-mytalk',
+			'pt-preferences',
+			'pt-logout'
+		];
+		for ( var i = 0; i < anchorIds.length; i++ ) {
+			var anchor = document.getElementById( anchorIds[ i ] );
+			if ( !anchor ) {
+				continue;
+			}
+			var dropdown = anchor.closest( '.dropdown' );
+			if ( !dropdown ) {
+				continue;
+			}
+			var toggle = dropdown.querySelector( ':scope > .dropdown-toggle' );
+			if ( toggle ) {
+				return toggle;
 			}
 		}
-		return toggles[ 0 ] || null;
+		return null;
 	}
 
 	function setBadge( el, count ) {

--- a/resources/styles/labki-tweeki.css
+++ b/resources/styles/labki-tweeki.css
@@ -70,6 +70,42 @@
 	color: var(--labki-text-muted);
 }
 
+/* === Dark-mode form input contrast ===
+   MediaWiki's edit textarea (#wpTextbox1) carries .mw-editfont-*
+   but no .form-control, so Bootstrap 5.3's `--bs-body-bg`-based
+   dark styling never matches it — the textarea renders against
+   the browser's hardcoded white. Light text on white is
+   unreadable. We scope to #content so the navbar search keeps
+   Tweeki's own styling, and use !important because Tweeki's
+   compiled CSS module loads after ours; without it our color/bg
+   ties on specificity and Tweeki's `--bs-body-bg` (which adapts
+   for elements that DO carry .form-control) wins by cascade. */
+[data-bs-theme="dark"] #content :is(
+	textarea,
+	select,
+	input:not([type]),
+	input[type="text"],
+	input[type="search"],
+	input[type="url"],
+	input[type="email"],
+	input[type="password"],
+	input[type="number"],
+	input[type="tel"],
+	input[type="date"],
+	input[type="datetime-local"],
+	input[type="time"]
+) {
+	background-color: var(--labki-bg-subtle) !important;
+	color: var(--labki-text) !important;
+	border-color: var(--labki-border) !important;
+}
+
+[data-bs-theme="dark"] #content :is(textarea, select, input):focus {
+	background-color: var(--labki-surface) !important;
+	color: var(--labki-text) !important;
+	border-color: var(--labki-accent) !important;
+}
+
 /* === Theme toggle button === */
 /* Strip the default link underline / dropdown caret styling so the
    icon-only toggle reads as a button. */
@@ -276,6 +312,80 @@ footer.footer a,
 .toc {
 	background-color: var(--labki-bg-subtle);
 	border: 1px solid var(--labki-border);
+}
+
+/* Tweeki's scroll-spy TOC (#tweekiTOC) sits in #sidebar-right but
+   appears visually on the LEFT thanks to the flex `order` rules
+   below. Tweeki's compiled CSS hardcodes:
+     * `#toctitle h2 a { background-color: #e9ecef }` — the "to top"
+       pill stays a bright Bootstrap gray-200 in both themes.
+     * `#toc a { color: #999 }` and `#toc a.active { color: #000 }`
+       — gray inactive items, BLACK active item, both readable on
+       a white surface but unreadable on a dark one.
+   Tweeki's CSS module loads AFTER ours and uses identical-
+   specificity selectors (#tweekiTOC #toctitle h2 a), so cascade
+   ties go to Tweeki — !important is the only reliable way to
+   override the hardcoded vendor colors without rewriting every
+   selector to outscore Tweeki's. */
+#tweekiTOC {
+	color: var(--labki-text);
+}
+
+#tweekiTOC #toctitle,
+#tweekiTOC .toctitle {
+	background-color: transparent;
+	color: var(--labki-heading);
+	border-bottom: 1px solid var(--labki-border);
+	padding-bottom: 0.4rem;
+	margin-bottom: 0.5rem;
+}
+
+#tweekiTOC #toctitle h2,
+#tweekiTOC .toctitle h2 {
+	color: var(--labki-heading);
+	border-bottom: none;
+	padding-bottom: 0;
+	font-size: 0.95rem;
+	margin: 0;
+}
+
+/* "To top" link: bare <a> inside the toctitle h2 (no class). Tweeki
+   hardcodes its background to gray-200; replace with our subtle
+   surface token so it flips with [data-bs-theme]. */
+#tweekiTOC #toctitle h2 a,
+#tweekiTOC .toctitle h2 a {
+	background-color: var(--labki-bg-subtle) !important;
+	color: var(--labki-accent) !important;
+	font-size: 0.75rem;
+	font-weight: normal;
+	text-decoration: none;
+	border: 1px solid var(--labki-border);
+}
+
+#tweekiTOC #toctitle h2 a:hover,
+#tweekiTOC #toctitle h2 a:focus,
+#tweekiTOC .toctitle h2 a:hover,
+#tweekiTOC .toctitle h2 a:focus {
+	background-color: var(--labki-border) !important;
+	color: var(--labki-accent-hover) !important;
+	text-decoration: none;
+}
+
+/* Inactive scrollspy items: Tweeki sets `#toc a { color: #999 }`
+   which reads OK on light surface but is muddy on dark. Override
+   to our muted text token. */
+#tweekiTOC #toc a {
+	color: var(--labki-text-muted) !important;
+}
+
+/* Active scrollspy item: Tweeki sets `#toc a.active { color: #000 }`
+   — pure black is invisible against the dark TOC surface. Lift to
+   accent + bold so the current section reads in both themes. */
+#tweekiTOC #toc a.active,
+#tweekiTOC #toc a:hover,
+#tweekiTOC #toc a:focus {
+	color: var(--labki-accent) !important;
+	font-weight: 600;
 }
 
 /* === Right sidebar collapse drawer ===


### PR DESCRIPTION
## Summary

Five UX fixes packaged together. Each was reproduced and verified in the dev compose stack.

* **Default theme to light.** Drop the `prefers-color-scheme` dark fallback in both the inline head bootstrap and `labki-tweeki.js` so first-visit appearance is a single canonical look regardless of the visitor's OS theme.

* **Eliminate the sidebar empty-state flash.** `BeforePageDisplay` now reads `OutputPage::getTOCData()` and pre-applies `html.sidebar-empty` when the parser produced fewer than 4 sections (matching MediaWiki's TOC rendering threshold) or no TOCData at all. A per-URL `labki.sidebarEmptyCache` map, written post-paint by `labki-tweeki.js`, overrides the server hint on revisits — any first-visit miss self-heals on the second load. The earlier branch's `hideEmptySidebar` is replaced by a single `setSidebarEmpty(html, empty)` helper that uses the no-transition reflow trick in both directions, so a server hint that turns out wrong reveals/hides silently rather than animating.

* **Dark-mode form input contrast.** `#wpTextbox1` carries `.mw-editfont-monospace` but no `.form-control`, so Bootstrap 5.3's `--bs-body-bg`-driven dark styling never reaches it — the textarea rendered against the browser default white. Override bg/color/border with `!important` inside `#content` under `[data-bs-theme="dark"]`, also covering bare `<textarea>` / `<input>` / `<select>` from MW edit forms, Page Forms, and similar.

* **TOC light/dark rework.** Tweeki's compiled CSS hardcodes the "to top" pill to gray-200 and the active scrollspy item to pure black; both ignore `data-bs-theme`, and Tweeki's CSS module loads after ours, so equal-specificity selectors lose the cascade tie. Override `#tweekiTOC` toctitle, the to-top anchor, inactive items, and the active scrollspy state with our surface tokens + `!important` so the panel flips cleanly.

* **Anchor the notification badge to the user dropdown.** `findUserToggle()` was matching the first `.dropdown-toggle` inside any `.nav` / `.navbar-nav`, which captured the leftmost `MediaWiki:Tweeki-navbar-left` dropdown — the badge landed on the wrong element. Walk up from a known PERSONAL-menu item id (`pt-notifications-*`, `pt-userpage`, `pt-logout`) to the enclosing `.dropdown` and return its toggle instead.

## Test plan

- [x] Fresh incognito with OS in dark: site lands light
- [x] `Main_Page` (1 heading, < 4 threshold) emits `apply=true` in the inline bootstrap, sidebar pre-hidden, no first-paint flash
- [x] `EmptyTest` (0 headings) and `Special:*` (null TOCData) likewise emit `apply=true`
- [x] `ManyHeadings` (5 headings) emits `apply=false`, sidebar visible from first paint
- [x] localStorage `labki.sidebarEmptyCache` populated after first visit, overrides server hint on revisits
- [x] Edit page in dark mode: `#wpTextbox1` background is `--labki-bg-subtle`, text readable
- [x] TOC "to top" link uses surface tokens (subtle bg + accent text), readable in both themes
- [x] Active scrollspy item reads in dark mode (accent blue + bold instead of hardcoded `#000`)
- [x] Notification badge lands on user dropdown in `navbar-right`, not on `navbar-left` items

🤖 Generated with [Claude Code](https://claude.com/claude-code)