### PR TITLE
Expose nsfr_img_auth.php at doc root for NSFileRepo

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -37,6 +37,11 @@ COPY extensions-git/sources.txt /tmp/sources.txt
 COPY extensions-git/clone-extensions.sh /usr/local/bin/clone-extensions.sh
 RUN chmod +x /usr/local/bin/clone-extensions.sh && /usr/local/bin/clone-extensions.sh /tmp/sources.txt
 
+# NSFileRepo's nsfr_img_auth.php must live at the document root so MediaWiki's
+# img_auth rewrite can reach it. Copy (don't symlink) — PHP's __DIR__ resolves
+# through symlinks to the real path, defeating the relocation.
+RUN cp /var/www/html/extensions/NSFileRepo/nsfr_img_auth.php /var/www/html/nsfr_img_auth.php
+
 # Install platform Composer dependencies
 COPY composer/composer.platform.json /var/www/html/composer.local.json
 

--- a/extensions-git/sources.txt
+++ b/extensions-git/sources.txt
@@ -6,6 +6,6 @@ ConfirmAccount https://gerrit.wikimedia.org/r/mediawiki/extensions/ConfirmAccoun
 MWAssistant https://github.com/labki-org/MWAssistant.git main extension
 SemanticSchemas https://github.com/labki-org/SemanticSchemas.git feature/dispatcher-bakes-display-schema extension
 LabkiPageFormsInputs https://github.com/labki-org/LabkiPageFormsInputs.git main extension
-NSFileRepo https://gerrit.wikimedia.org/r/mediawiki/extensions/NSFileRepo.git REL1_44 extension
+NSFileRepo https://github.com/wikimedia/mediawiki-extensions-NSFileRepo.git REL1_44 extension
 Citizen https://github.com/StarCitizenTools/mediawiki-skins-Citizen.git v3.6.0 skin
 Tweeki https://github.com/thaider/Tweeki.git master skin


### PR DESCRIPTION
## Summary
- Copy `nsfr_img_auth.php` from `extensions/NSFileRepo/` into the document root so MediaWiki's `img_auth` rewrite can find it. Using `cp` (not `ln -s`) because PHP's `__DIR__` resolves through symlinks to the real path, defeating the relocation.

> Note: the commit on this branch also contains a `sources.txt` line for NSFileRepo (Gerrit→GitHub mirror), but that same change has since landed on `main` via ecff921, so the PR diff against current `main` shows **only the Dockerfile change**. Merge will be clean.

## Test plan
- [ ] CI smoke-test (prod + dev) passes — `/var/www/html/nsfr_img_auth.php` is present in the image after build.