### PR TITLE
Tokenize catlinks and fieldsets for dark-mode coverage

### DIFF
--- a/resources/styles/labki-tweeki.less
+++ b/resources/styles/labki-tweeki.less
@@ -415,6 +415,59 @@ footer.footer.bg-light,
 	border-color: var(--labki-border);
 }
 
+/* === Catlinks ===
+   Tweeki hides catlinks by default (`skins.tweeki.styles` ships
+   `#catlinks { display: none }`); Labki re-shows them as a subtle-
+   surface bar on every page that has visible categories. Was
+   previously a per-wiki override in `MediaWiki:Tweeki.css` using
+   hex literals — consolidated here so every deployment gets it
+   without manual seeding, and tokenized so light/dark flip
+   automatically. The `:not(.catlinks-allhidden)` keeps the hide
+   path intact for catlinks-empty pages (Skin sets that class on
+   the outer div when no visible categories). Specificity (1,1,0)
+   beats Tweeki's `#catlinks` (1,0,0) and MW's `.catlinks` (0,1,0)
+   without `!important`. */
+#catlinks:not(.catlinks-allhidden) {
+	display: block;
+	margin-top: 1.5em;
+	padding: 0.5em 0.75em;
+	background: var(--labki-bg-subtle);
+	border: 1px solid var(--labki-border);
+	border-radius: 4px;
+	color: var(--labki-text);
+}
+
+#catlinks .mw-normal-catlinks ul,
+#catlinks .mw-normal-catlinks li {
+	display: inline;
+	padding-left: 0;
+}
+
+#catlinks .mw-normal-catlinks li:not(:last-child)::after {
+	content: " | ";
+	color: var(--labki-text-muted);
+}
+
+#catlinks a {
+	color: var(--labki-accent);
+}
+
+/* === Fieldset / legend ===
+   HTML <fieldset> + <legend> (used by Cargo filter boxes, MW prefs
+   subsections, PageForms input groups) renders with browser-default
+   light borders and the legend paints through to the page bg. On dark
+   mode the body bg is dark, but Bootstrap Reboot's `legend` rule sets
+   no explicit bg and some browsers leak the system color through —
+   pin both to tokens so they flip cleanly. */
+#content fieldset {
+	border-color: var(--labki-border);
+}
+
+#content legend {
+	color: var(--labki-text);
+	background-color: transparent;
+}
+
 #content .mw-search-profile-tabs .search-types li {
 	background-color: transparent;
 }


### PR DESCRIPTION
## Summary

- Moved the catlinks bar styling from per-wiki `MediaWiki:Tweeki.css` into `labki-tweeki.less` using `--labki-*` tokens, so it flips correctly in dark mode and every Labki deployment gets the bar by default (no manual wiki-page seeding required).
- Selector specificity (1,1,0) beats Tweeki's `#catlinks { display: none }` (1,0,0) and MW core's `.catlinks { background: #f9f9f9 }` (0,1,0) cleanly — no `!important`.
- Added token-aware re-paints for `#content fieldset` and `#content legend` so HTML fieldsets (Cargo filter boxes, prefs subsections, PageForms input groups) flip with theme.

## Migration note

Existing wikis carrying the catlinks rule in `MediaWiki:Tweeki.css` should clear that block — same selector at the same specificity, but `site.styles` loads after the skin module, so the wiki-page rule otherwise wins by source order and the dark-mode flip won't take effect.

## Test plan

- [ ] Hard-refresh a page with at least one visible category in **light** mode → catlinks bar reads as before (subtle gray surface, separator pipes between categories).
- [ ] Toggle to **dark** mode → catlinks bar flips to dark subtle surface; pipes and links remain readable.
- [ ] Visit a page with **no visible categories** → bar stays hidden (the `:not(.catlinks-allhidden)` clause).
- [ ] Visit any page with a `<fieldset><legend>` group (Cargo filter, `Special:Preferences` subsection) → border uses the labki border token; legend bg is transparent over the surface.
- [ ] On an existing wiki, clear the matching block from `MediaWiki:Tweeki.css` and re-test dark mode catlinks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)