### PR TITLE
Tokenize ConfirmAccount request rows for dark-mode coverage

### DIFF
--- a/resources/styles/labki-tweeki.less
+++ b/resources/styles/labki-tweeki.less
@@ -468,6 +468,23 @@ footer.footer.bg-light,
 	background-color: transparent;
 }
 
+/* === ConfirmAccount extension ===
+   ConfirmAccount's `confirmaccount.css` paints request-row chrome
+   with hardcoded pastels (`#f9f9f9`, `#f0fff0`, `#f0ffff`) — a
+   pale-green `.mw-confirmaccount-type-0` body becomes unreadable
+   in dark mode (light text on near-white). Re-paint with tokens:
+   the queue-type tint is dropped so all queues read uniformly
+   against the dark surface, with the existing `mw-confirmaccount-
+   bar` red border kept as the unread/pending signal. */
+#content .mw-confirmaccount-bar,
+#content .mw-confirmaccount-type-0,
+#content .mw-confirmaccount-type-1,
+#content .mw-confirmaccount-body-0,
+#content .mw-confirmaccount-body-1 {
+	background-color: var(--labki-bg-subtle);
+	color: var(--labki-text);
+}
+
 #content .mw-search-profile-tabs .search-types li {
 	background-color: transparent;
 }


### PR DESCRIPTION
## Summary

Re-paints the ConfirmAccount extension's request-row chrome (`.mw-confirmaccount-bar`, `.mw-confirmaccount-type-{0,1}`, `.mw-confirmaccount-body-{0,1}`) using `--labki-*` tokens.

The extension's bundled `confirmaccount.css` paints these with hardcoded pastels (`#f9f9f9`, `#f0fff0`, `#f0ffff`). The pale-green type-0 body in particular renders unreadable in dark mode — light text lands on a near-white surface (see screenshot in issue).

The queue-type tint is dropped intentionally: all queues now read uniformly against the dark surface, with the existing red `bar` border kept as the pending-request signal.

## Test plan

- [ ] Open `Special:ConfirmAccounts` (admin) in **light** mode → request rows render with the labki subtle-surface bg, text legible.
- [ ] Toggle to **dark** mode → rows flip to the dark subtle surface; "Username", "Email", etc. labels and values readable on the dark bg.
- [ ] Pending-request red border on `.mw-confirmaccount-bar` is preserved.

## Note for follow-up

A second light-mode-only patch was reported on a user-profile page ("Researcher" header pill / "Organizational Role" pill) — couldn't identify the painting selector from the served bundle, suggesting it lives in the wiki's templates as inline `style=""` or a custom class in `MediaWiki:Common.css`/`MediaWiki:Tweeki.css`. Will need rendered HTML to fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)