### PR TITLE
Dark-mode re-paints for PageForms Select2 widgets

### DIFF
--- a/resources/styles/labki-tweeki.less
+++ b/resources/styles/labki-tweeki.less
@@ -499,6 +499,119 @@ footer.footer.bg-light,
 	color: var(--labki-accent);
 }
 
+/* === PageForms Select2 widgets ===
+   PageForms loads the Select2 library for `tokens`, `combobox`,
+   and Property-driven autocomplete inputs (per Extension:Page
+   Forms/Select2 for autocompletion). Vendored
+   `libs/foreign/select2/select2.css` paints `.select2-selection--
+   {single,multiple}` with `#fff`, the selected dropdown row with
+   `#ddd`, the disabled state with `#eee`, and all borders with
+   `#aaa` — readable in light mode, but bright pills on a dark page.
+
+   PageForms maintainers haven't added Codex-token-aware CSS yet,
+   and per MW core's "Recommendations for night mode compatibility"
+   the standard intervention for un-tokenized extension surfaces is
+   for the skin/platform to re-paint those classes under the
+   canonical color-mode signals (`.skin-theme-clientpref-night` /
+   `[data-bs-theme="dark"]`).
+
+   Selectors are NOT scoped to #content: Select2's results dropdown
+   is portaled directly under <body> on open, so #content-scoped
+   rules can't reach it. The color-mode signal lives on <html>, so
+   the ancestor match still works for the portaled dropdown. */
+.skin-theme-clientpref-night,
+[data-bs-theme="dark"] {
+	.select2-container--default {
+		.select2-selection--single,
+		.select2-selection--multiple {
+			background-color: var(--labki-bg-subtle);
+			color: var(--labki-text);
+			border-color: var(--labki-border);
+		}
+
+		.select2-selection--single .select2-selection__rendered {
+			color: var(--labki-text);
+		}
+
+		.select2-selection__placeholder {
+			color: var(--labki-text-muted);
+		}
+
+		/* Single-select dropdown chevron — default uses `border-top-
+		   color: #888` which lands as a dim arrow on dark; lift to
+		   the muted text token for consistent contrast. */
+		.select2-selection--single .select2-selection__arrow b {
+			border-top-color: var(--labki-text-muted);
+		}
+
+		&.select2-container--open .select2-selection--single .select2-selection__arrow b {
+			border-bottom-color: var(--labki-text-muted);
+		}
+
+		/* Pill chips on multi-select (e.g. token inputs). The chip's
+		   bg is set via `--bs-tertiary-bg`-style hex literal in
+		   select2.css; we use the border token because it sits on
+		   `--labki-bg-subtle` and reads as a slightly-elevated chip. */
+		.select2-selection--multiple .select2-selection__choice {
+			background-color: var(--labki-border);
+			color: var(--labki-text);
+			border-color: var(--labki-border);
+		}
+
+		.select2-selection--multiple .select2-selection__choice__remove {
+			color: var(--labki-text);
+
+			&:hover {
+				color: var(--labki-accent);
+			}
+		}
+
+		/* Inline search field within multi-select; sits on the chip
+		   row so transparent + token text is what we want. */
+		.select2-search--inline .select2-search__field {
+			color: var(--labki-text);
+			background: transparent;
+		}
+
+		/* Disabled state. Vendored bg is `#eee`; replace with our
+		   subtle surface and dim via opacity so the disabled signal
+		   reads on dark. */
+		&.select2-container--disabled .select2-selection--single,
+		&.select2-container--disabled .select2-selection--multiple {
+			background-color: var(--labki-bg-subtle);
+			opacity: 0.6;
+		}
+
+		/* Results dropdown rows. */
+		.select2-results__option {
+			color: var(--labki-text);
+		}
+
+		.select2-results__option[aria-selected=true] {
+			background-color: var(--labki-border);
+			color: var(--labki-text);
+		}
+
+		.select2-results__option--highlighted[aria-selected] {
+			background-color: var(--labki-accent);
+			color: #fff;
+		}
+	}
+
+	/* Dropdown panel (portaled to <body>; un-#content-scoped). */
+	.select2-dropdown {
+		background-color: var(--labki-bg-subtle);
+		color: var(--labki-text);
+		border-color: var(--labki-border);
+	}
+
+	.select2-search--dropdown .select2-search__field {
+		background-color: var(--labki-surface);
+		color: var(--labki-text);
+		border-color: var(--labki-border);
+	}
+}
+
 /* Browser-default <hr> renders with hardcoded grays. */
 #content hr {
 	border: none;


### PR DESCRIPTION
## Summary

PageForms loads the Select2 library for `tokens`, `combobox`, and Property-driven autocomplete inputs. The vendored `extensions/PageForms/libs/foreign/select2/select2.css` paints widget chrome with hardcoded `#fff` / `#ddd` / `#eee` / `#aaa` literals — readable in light mode, but the widget renders as a bright pill on a dark page when the host wiki is in dark mode.

The actual `<input>` element is already painted by our existing `#content input[type="text"]` rule, which is why screenshots showed the inner cursor area as dark while the wrapping Select2 chrome stayed light.

## Why this lives in labki-platform

Per [MW core's "Recommendations for night mode compatibility on Wikimedia wikis"](https://www.mediawiki.org/wiki/Recommendations_for_night_mode_compatibility_on_Wikimedia_wikis), extensions should ideally use Codex tokens (with `--color-base` etc.) so dark mode works automatically. PageForms hasn't been updated to that pattern yet, so the recommended interim is for the skin / platform to re-paint the classes under the canonical color-mode signals — same shape as our existing re-paints for ConfirmAccount, MW factbox, MW prefs, etc.

## How it triggers

Gated by either of the standard color-mode signals on `<html>`:
- `.skin-theme-clientpref-night` — MediaWiki's canonical dark-mode class
- `[data-bs-theme=\"dark\"]` — Bootstrap 5.3's color-mode attribute

Both are stamped by the labki-tweeki bootstrap script. Light mode and non-dark-aware skins see no change.

## Coverage

- Single + multi selection container (bg, color, border)
- Selection text + placeholder
- Single-select dropdown chevron (closed + open states)
- Pill chips on multi-select (token inputs) + remove (×) button (with accent hover)
- Inline search field within multi-select
- Disabled state (subtle bg + opacity dim)
- Results dropdown rows: default / selected / highlighted
- Portaled `.select2-dropdown` panel + the in-dropdown search field

## Selector scoping note

Selectors are deliberately **not** scoped to `#content` — Select2's results dropdown is portaled directly under `<body>` on open, so a `#content`-scoped rule would never reach it. The color-mode signal lives on `<html>`, so the ancestor-match selector still reaches the portaled dropdown.

## Test plan

- [ ] Open a PageForms form (form-edit on a SemanticSchemas-managed page) in **light** mode → autocomplete fields, token pill inputs (Location-style), and combobox inputs render unchanged from before.
- [ ] Toggle to **dark** mode → all of the above flip to the labki subtle surface; pill chips read as slightly-elevated tokens; cursor (`<input>`) and chrome (Select2 wrapper) now match.
- [ ] Click into a single-select autocomplete → the portaled dropdown panel opens with dark surface; rows are readable; hovering a row shows accent highlight; selected row reads correctly.
- [ ] Click into a multi-select tokens field → search box within the dropdown reads on dark; adding/removing chips works visually.
- [ ] Disable a field via `disabled` form parameter → field renders dim but still on the dark surface (no white flash).

## Related work

This is the third in the recent chain of PageForms-form dark-mode fixes:
- LabkiPageFormsInputs PR #7 — flatpickr calendar/time pickers
- SemanticSchemas PR #155 (latest commits) — table section-header rows + sidebox frame
- This PR — Select2 widgets

🤖 Generated with [Claude Code](https://claude.com/claude-code)