### PR TITLE
Add labki-forum: forum-style topics bundled on DiscussionTools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Labki Forum**: bundled forum-style discussion topics on top of MediaWiki DiscussionTools. Drop-in `.labki-forum-new-post-btn` (or `[data-labki-forum-new-post]`) creates a Talk-namespace subpage with `<UTC-timestamp>_<username>` slug and routes to DT's new-topic widget. Topic pages render as forum cards (outer frame, accent-bar first post, indented reply cards, button-styled reply links) with a `← parent` breadcrumb back-link. First H2 promotes to DISPLAYTITLE. Four custom SMW properties (`Topic subject`, `Topic starter`, `Comment count`, `Participant count`) populate per topic so a landing page can render a forum index via `#ask`. Works with any namespace pair the deployer sets up; documented in [`docs/labki-forum.md`](docs/labki-forum.md).
 - Custom Tweeki skin theme with academic color palette and layout defaults
 - CONTRIBUTING.md with contributor guidelines
 - CHANGELOG.md for tracking releases
@@ -32,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 - Timestamp-localization JavaScript in `labki-tweeki.js`. The string-rewrite was overriding MediaWiki user date preferences with a hardcoded format. Date display now defers to SMW query authors (`?Date`, `?Date#-F[...]`) and MediaWiki preferences.
 - `--labki-warning` and `--labki-radius` design tokens — defined but unreferenced anywhere in the codebase.
+- **WikiForum extension**. Replaced by the new bundled Labki Forum module (DiscussionTools-based). Removed from `extensions-git/sources.txt` and `mediawiki/extensions.platform.php`.
 
 ### Notes
 - A future MediaWiki version is expected to ship a `darkmode-override()` LESS mixin (currently absent in 1.44.5) for skins to wrap per-element dark-mode overrides while waiting for upstream Codex migration. Adopt once available; until then the per-element rules in `labki-tweeki.less` carry the same intent in plain LESS.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ The platform defines a single authoritative MediaWiki environment. All platform-
 -   **[Technical Contract](docs/contract.md)**: Specifications for environment variables, paths, and platform behavior.
 -   **[User Guide](runtime/README.md)**: How to deploy and configure the runtime distribution.
 -   **[Extension Dev Guide](docs/extension-dev-guide.md)**: How to use this platform to test your own extensions.
+-   **[Tweeki Runbook](docs/tweeki-runbook.md)**: Switching the platform skin to Tweeki and the customization surface it exposes.
+-   **[Labki Forum Runbook](docs/labki-forum.md)**: DiscussionTools-as-forum bundled feature — namespace setup, button placement, SMW forum index.
 -   **[Changelog](CHANGELOG.md)**: Release history and notable changes.
 
 ## Repository Structure

--- a/ci/smoke-test.sh
+++ b/ci/smoke-test.sh
@@ -94,6 +94,13 @@ verify_module() {
 echo "[smoke-test] Verifying platform ResourceLoader modules..."
 verify_module skin.labki.tweeki.styles  styles
 verify_module skin.labki.tweeki.scripts scripts
+# Forum module is gated on extensions being loaded (it's registered in
+# extensions.platform.php). Skip in 'disabled' mode where the file doesn't
+# load and the module names are absent from ResourceLoader.
+if [ "$EXTENSIONS_MODE" = "enabled" ]; then
+    verify_module ext.labki.forum.styles styles
+    verify_module ext.labki.forum        scripts
+fi
 
 # --- Probe runtime config from inside the container ---
 # We avoid the HTTP API for this because the wiki is private
@@ -114,6 +121,8 @@ DEFAULT_SKIN=$(extract DEFAULT_SKIN)
 SKINS=$(extract SKINS)
 FILE_EXTS=$(extract FILE_EXTENSIONS)
 EXT_NAMES=$(extract EXTENSIONS)
+NAMESPACES=$(extract NAMESPACES)
+SMW_FORUM_PROPS=$(extract SMW_FORUM_PROPS)
 
 echo "[smoke-test] Verifying default skin..."
 [ "$DEFAULT_SKIN" = "tweeki" ] \
@@ -147,6 +156,47 @@ else
     if contains_csv "$EXT_NAMES" "SemanticMediaWiki"; then
         fail "SemanticMediaWiki present despite MW_DISABLE_PLATFORM_EXTENSIONS=1."
     fi
+fi
+
+# Forum / Forum_talk namespaces (3000/3001) are declared by the dev overlay
+# at compose/dev-config/LocalSettings.user.php — only mounted when the
+# compose target is 'dev'. On 'prod' they're absent by design.
+if [ "$DOCKER_TARGET" = "dev" ] && [ "$EXTENSIONS_MODE" = "enabled" ]; then
+    echo "[smoke-test] Verifying forum namespaces are registered..."
+    for ns in 3000 3001; do
+        contains_csv "$NAMESPACES" "$ns" \
+            || fail "namespace ID '$ns' missing from probe (dev overlay didn't load?)."
+    done
+
+    echo "[smoke-test] Verifying labki-forum SMW custom properties..."
+    for pid in ___forum_subject ___forum_starter ___forum_comments ___forum_participants; do
+        contains_csv "$SMW_FORUM_PROPS" "$pid" \
+            || fail "SMW custom property '$pid' is not registered (forum hook didn't fire?)."
+    done
+
+    # End-to-end probe: parse a synthetic Forum_talk subpage in-memory and
+    # verify the labki-forum hooks set DISPLAYTITLE, DEFAULTSORT, and the
+    # four SMW properties to the values we expect for known wikitext.
+    echo "[smoke-test] Probing labki-forum hooks via in-memory parse..."
+    FORUM_PROBE=$(docker compose -f "$COMPOSE_FILE" exec -T wiki php /opt/labki/scripts/probe-forum-page.php) \
+        || { echo "[smoke-test] forum-probe output:"; echo "$FORUM_PROBE"; fail "probe-forum-page.php failed inside container."; }
+    echo "[smoke-test] Forum probe returned:"
+    echo "$FORUM_PROBE" | sed 's/^/[smoke-test]   /'
+
+    fextract() { echo "$FORUM_PROBE" | grep "^$1=" | head -1 | cut -d= -f2-; }
+
+    [ "$(fextract DISPLAYTITLE)" = "Hello smoke" ] \
+        || fail "DISPLAYTITLE is '$(fextract DISPLAYTITLE)', expected 'Hello smoke' (first H2 was not promoted)."
+    [ "$(fextract DEFAULTSORT)" = "Forum talk:Smoketest/2026-01-01 120000 Bob" ] \
+        || fail "DEFAULTSORT is '$(fextract DEFAULTSORT)', expected canonical title (SMW sortkey hijack regression)."
+    [ "$(fextract FORUM_SUBJECT)" = "Hello smoke" ] \
+        || fail "FORUM_SUBJECT SMW property is '$(fextract FORUM_SUBJECT)', expected 'Hello smoke'."
+    [ "$(fextract FORUM_COMMENTS)" = "3" ] \
+        || fail "FORUM_COMMENTS is '$(fextract FORUM_COMMENTS)', expected 3 (one per (UTC) signature)."
+    [ "$(fextract FORUM_PARTICIPANTS)" = "2" ] \
+        || fail "FORUM_PARTICIPANTS is '$(fextract FORUM_PARTICIPANTS)', expected 2 unique authors."
+    [ "$(fextract FORUM_STARTER)" = "User:Bob" ] \
+        || fail "FORUM_STARTER is '$(fextract FORUM_STARTER)', expected 'User:Bob' (case-folding regression?)."
 fi
 
 echo "[smoke-test] SUCCESS. Tearing down..."

--- a/compose/dev-config/LocalSettings.user.php
+++ b/compose/dev-config/LocalSettings.user.php
@@ -31,3 +31,31 @@ $wgContentNamespaces[] = NS_FORUM;
 
 $wgNamespacePermissionLockdown[NS_FORUM]['edit']   = [ 'sysop' ];
 $wgNamespacePermissionLockdown[NS_FORUM]['create'] = [ 'sysop' ];
+
+// Enable SMW so #ask / property annotations work in Forum landing pages
+// and inside topic threads (e.g. an index of Forum_talk:* subpages on
+// Forum:Miniscopes).
+$smwgNamespacesWithSemanticLinks[NS_FORUM]      = true;
+$smwgNamespacesWithSemanticLinks[NS_FORUM_TALK] = true;
+
+// Built-in SMW special properties (default ships only _MDAT). Adding
+// Creation date + Last editor + Display title of lets a forum landing page
+// render a "Started / Last activity / Last by / Subject" index over
+// Forum_talk subpages.
+//
+// Schema note: changes to this list (or to the custom-property registry in
+// extensions.platform.php) are SQL-store schema changes. After updating,
+// run inside the wiki container:
+//   php extensions/SemanticMediaWiki/maintenance/setupStore.php
+//   php extensions/SemanticMediaWiki/maintenance/rebuildData.php -n 3000,3001
+//
+// SESP note: _CUSER ("Page author", first author) would surface
+// "Started by" via SESP, but SESP's CreatorPropertyAnnotator type-hints
+// the legacy \Title class while MW 1.44 emits \MediaWiki\Title\Title —
+// runs throw a TypeError. Re-enable once SESP upstreams the namespaced
+// type. The custom ___forum_starter property in extensions.platform.php
+// fills the same role in the meantime.
+$smwgPageSpecialProperties = array_merge(
+    $smwgPageSpecialProperties ?? [],
+    [ '_CDAT', '_LEDT', '_DTITLE' ]
+);

--- a/compose/dev-config/LocalSettings.user.php
+++ b/compose/dev-config/LocalSettings.user.php
@@ -1,0 +1,33 @@
+<?php
+// LocalSettings.user.php — overlay loaded by the dev compose at
+// compose/docker-compose.dev.yml (mounted into the container at
+// /mw-config/LocalSettings.user.php).
+//
+// Sets up a Forum / Forum_talk namespace pair so the bundled labki-forum
+// module (registered in mediawiki/extensions.platform.php) can be exercised
+// end-to-end. Drop the .labki-forum-new-post-btn span on a Forum:* page;
+// the resulting topic lands at Forum_talk:.../<UTC-timestamp>_<username>.
+//
+// Forum: subject pages are sysop-only (curated landing pages); Forum_talk:
+// subpages inherit MediaWiki's standard talk-namespace edit rights — i.e.
+// any logged-in user can post topics and reply. This file is intended for
+// the dev test environment only; production deployments choose their own
+// namespace policy via runtime/config/LocalSettings.user.php.
+
+if ( !defined( 'MEDIAWIKI' ) ) {
+    exit;
+}
+
+define( 'NS_FORUM',      3000 );
+define( 'NS_FORUM_TALK', 3001 );
+
+$wgExtraNamespaces[NS_FORUM]      = 'Forum';
+$wgExtraNamespaces[NS_FORUM_TALK] = 'Forum_talk';
+
+$wgNamespacesWithSubpages[NS_FORUM]      = true;
+$wgNamespacesWithSubpages[NS_FORUM_TALK] = true;
+
+$wgContentNamespaces[] = NS_FORUM;
+
+$wgNamespacePermissionLockdown[NS_FORUM]['edit']   = [ 'sysop' ];
+$wgNamespacePermissionLockdown[NS_FORUM]['create'] = [ 'sysop' ];

--- a/compose/docker-compose.dev.yml
+++ b/compose/docker-compose.dev.yml
@@ -40,6 +40,11 @@ services:
       # extensions.platform.php / LocalSettings.base.php take effect on
       # touch (subject to PHP opcache mtime invalidation).
       - ../mediawiki:/opt/labki/mediawiki
+      # Dev-only overlay: namespace declarations and any other settings
+      # that aren't part of the platform default but should be present
+      # in a developer's running wiki for end-to-end testing of bundled
+      # features (currently: Forum / Forum_talk for labki-forum).
+      - ./dev-config:/mw-config
     # volumes:
     #   - ../../MyExtension:/var/www/html/extensions/MyExtension
     #   - ../../MySkin:/mw-user-skins/MySkin

--- a/docs/labki-forum.md
+++ b/docs/labki-forum.md
@@ -1,0 +1,157 @@
+# Labki Forum Runbook
+
+Forum-style discussion topics built on top of MediaWiki **DiscussionTools**, using Talk-namespace subpages with auto-generated `<UTC-timestamp>_<username>` slugs. No dedicated forum extension; the entire feature is bundled into the platform as a small ResourceLoader module plus three PHP hooks.
+
+## What you get
+
+Bundled into the platform with no extra configuration beyond namespace setup:
+
+- A drop-in **"new topic" button** for any wiki page. Clicking it routes the user to DT's new-topic widget on a fresh subpage of the current page's talk-namespace counterpart.
+- **Forum-card styling** on the resulting topic pages (outer card frame, accent-bar first post, indented reply cards, button-styled reply links). Covers Tweeki and Vector-family skins; uses Codex tokens for light/dark theming.
+- A **"← parent" breadcrumb** at the top of every topic page, linking back to the subject-namespace landing page.
+- **`__DISPLAYTITLE__` auto-set** to the topic's first H2, so browser tabs and inbound wikilinks render the human-readable subject instead of the `<UTC>_<user>` slug.
+- **Four custom SMW properties** populated per topic so a landing page can render a forum index via `#ask`:
+  - `Topic subject` (Text) — first H2 of the page
+  - `Topic starter` (Page) — first signature author, as a `User:Name` link
+  - `Comment count` (Number) — count of signed `(UTC)` timestamps
+  - `Participant count` (Number) — unique authors
+
+## Setup for a new namespace pair
+
+Suppose you want a forum at `Forum:*` with topic pages under `Forum_talk:*`. In your `LocalSettings.user.php`:
+
+```php
+define( 'NS_FORUM',      3000 );
+define( 'NS_FORUM_TALK', 3001 );
+
+$wgExtraNamespaces[NS_FORUM]      = 'Forum';
+$wgExtraNamespaces[NS_FORUM_TALK] = 'Forum_talk';
+
+// Subpages must be enabled on the talk side — that's where topics live.
+$wgNamespacesWithSubpages[NS_FORUM]      = true;
+$wgNamespacesWithSubpages[NS_FORUM_TALK] = true;
+
+// Optional: make Forum: a content namespace so landing pages count
+// for Recent Changes / search defaults.
+$wgContentNamespaces[] = NS_FORUM;
+
+// Optional: lock down Forum: so only admins curate landing pages,
+// while Forum_talk: stays open to logged-in users for posting topics.
+$wgNamespacePermissionLockdown[NS_FORUM]['edit']   = [ 'sysop' ];
+$wgNamespacePermissionLockdown[NS_FORUM]['create'] = [ 'sysop' ];
+```
+
+The feature is **not Forum-specific**. The hooks fire on any odd-numbered namespace (i.e. any talk-side namespace) with a `/` in the page name — so `Project_talk:Foo/<slug>`, `User_talk:Bob/<slug>`, and plain `Talk:Article/<slug>` all pick up the forum chrome. Pick whatever namespace pair fits your use case.
+
+### Enabling SMW indexing for the forum index
+
+The four custom SMW properties register automatically the moment the platform's extensions load, but for them (and their associated `#ask` queries) to show data, SMW needs to be told the topic namespaces are queryable, plus a few built-in special properties enabled for the forum-index columns:
+
+```php
+$smwgNamespacesWithSemanticLinks[NS_FORUM]      = true;
+$smwgNamespacesWithSemanticLinks[NS_FORUM_TALK] = true;
+
+// _CDAT (Creation date), _LEDT (Last editor is), _DTITLE (Display title of)
+// surface the "Started", "Last by", and "Subject" columns of the forum index.
+$smwgPageSpecialProperties = array_merge(
+    $smwgPageSpecialProperties ?? [],
+    [ '_CDAT', '_LEDT', '_DTITLE' ]
+);
+```
+
+After changing this list you need to bump the SMW SQL store schema and re-index existing pages:
+
+```bash
+docker exec <wiki-container> php /var/www/html/extensions/SemanticMediaWiki/maintenance/setupStore.php
+docker exec <wiki-container> php /var/www/html/extensions/SemanticMediaWiki/maintenance/rebuildData.php -n 3000,3001
+```
+
+## Placing the "new topic" button
+
+Drop one of these on any page that should become a forum landing page:
+
+```html
+<!-- Bundled visual styling (uses the .labki-forum-new-post-btn class shipped in labki-forum.less) -->
+<span class="labki-forum-new-post-btn" role="button" tabindex="0">Make new post</span>
+
+<!-- Bring-your-own UI: pure behavioral hook, no styling attached -->
+<button class="my-button" data-labki-forum-new-post>Start a discussion</button>
+```
+
+On click, the handler:
+1. Reads the current page name (`Forum:Miniscopes`).
+2. Flips to the talk-namespace counterpart via `mw.Title.getTalkPage()` (`Forum_talk:Miniscopes`).
+3. Generates a slug from the current UTC timestamp and the viewer's username (`2026-05-08_120030_Daniel`).
+4. Navigates to `Forum_talk:Miniscopes/<slug>?action=edit&section=new`, which DT renders as its new-topic widget.
+
+The user types their subject (H2) and body, hits "Reply", and lands on the saved topic page styled as a forum card.
+
+## Forum index `#ask` query
+
+Paste this on a `Forum:*` landing page to render an index of its topics:
+
+```
+{{#ask: [[Forum talk:+]] [[~*Miniscopes/*]]
+ |mainlabel=Topic
+ |?Topic starter=Started by
+ |?Last editor is=Last by
+ |?Creation date#LOCL=Started
+ |?Modification date#LOCL=Last activity
+ |?Comment count=Replies
+ |?Participant count=People
+ |format=broadtable
+ |headers=plain
+ |sort=Modification date
+ |order=desc
+ |limit=20
+ |default=No topics yet.
+}}
+```
+
+Replace `Miniscopes` with the landing page's name. The `Topic` column auto-renders the H2 as link text (DISPLAYTITLE-driven), with the link target being the canonical slug-based URL.
+
+### Why `[[Forum talk:+]] [[~*Miniscopes/*]]` instead of `[[~Forum talk:Miniscopes/*]]`
+
+SMW's `~LIKE` pattern doesn't match the namespace prefix as a single token. Splitting into a namespace condition + a name pattern is the working idiom.
+
+## CSS hooks for customization
+
+The styling sits behind two top-level hooks you can override via `MediaWiki:Common.css` or per-skin custom CSS:
+
+| Selector | Scope |
+| :--- | :--- |
+| `.labki-forum-new-post-btn` | Bundled "new topic" button. Restyle freely; the click handler lives on the class plus the `[data-labki-forum-new-post]` attribute. |
+| `html.labki-forum-topic` | Set server-side on every odd-namespace subpage. All topic-card chrome (frame, accent stripe, reply cards, hidden `#firstHeading` / TOC) is scoped under this. Override individual rules to retune; remove the class server-side to opt out wholesale. |
+| `.labki-forum-back` | The "← parent" breadcrumb anchor in `#contentSub`. |
+
+## Known caveats
+
+### English-locale signature heuristic
+
+`Comment count` and `Participant count` are extracted by counting `(UTC)` timestamps and `[[User:Name]]` wikilinks in the saved revision's wikitext. Localized signatures (`(MEZ)` on de.wiki, etc.) will undercount. Switching to DT's authoritative `ContentHeadingItem::getCommentCount()` would require a deferred-update model since DT's parser needs already-rendered HTML. Acceptable for English-language deployments; revisit if shipping to a multilingual wiki.
+
+### Counts include the OP
+
+A topic with no replies reads as "1 comment, 1 participant" — Discourse-style. Subtract 1 in your `#ask` view if you want a strict "replies" count.
+
+### DISPLAYTITLE fires on every odd-namespace subpage
+
+Plain `Talk:Article/Archive_1` pages also pick up the forum chrome and DISPLAYTITLE auto-set. That's an acceptable default for a forum-oriented wiki; opt-out per-page by adding a `{{DISPLAYTITLE:...}}` override or overriding the styling locally. To scope strictly to a single namespace, narrow the namespace check in `mediawiki/extensions.platform.php`.
+
+### DEFAULTSORT is pinned
+
+The `ParserAfterParse` hook unconditionally sets `__DEFAULTSORT__` to the canonical prefixed title on forum topic pages. This neutralizes SMW's DisplayTitle annotator, which would otherwise hijack the sortkey to the displaytitle and break LIKE-pattern queries like `[[~*Miniscopes/*]]`. If you need a different sort key on a topic page, override it explicitly in the page's wikitext.
+
+### SESP `_CUSER` is broken on MW 1.44
+
+SESP's "Page author" property would surface "Started by" via a built-in route, but its `CreatorPropertyAnnotator` type-hints the legacy `\Title` class while MW 1.44 emits `\MediaWiki\Title\Title`, throwing a `TypeError` mid-rebuild. The custom `Topic starter` property fills the same role. Re-enable SESP's `_CUSER` once the upstream fix lands.
+
+## Where the wiring lives
+
+| File | Role |
+| :--- | :--- |
+| `mediawiki/extensions.platform.php` | Hook registrations: `SMW::Property::initProperties` (4 custom properties), `ParserAfterParse` (DISPLAYTITLE / DEFAULTSORT / SMW data), `BeforePageDisplay` (HTML class + breadcrumb subtitle). |
+| `resources/scripts/labki-forum.js` | Click handler bound to `.labki-forum-new-post-btn` and `[data-labki-forum-new-post]`. |
+| `resources/styles/labki-forum.less` | All visual styling (button + topic-card chrome). Codex tokens with hex fallbacks. |
+| `compose/dev-config/LocalSettings.user.php` | Reference deployment of the namespace + SMW configuration above (used by the dev compose target only). |
+| `scripts/probe-forum-page.php` | End-to-end smoke probe — saves a synthetic topic and reads back the hook outputs. Covered by `ci/smoke-test.sh`. |

--- a/extensions-git/sources.txt
+++ b/extensions-git/sources.txt
@@ -1,7 +1,6 @@
 # Format: <ExtensionName> <GitURL> <GitRef> <Type:extension|skin>
 MsUpload https://github.com/wikimedia/mediawiki-extensions-MsUpload.git REL1_44 extension
 Lockdown https://gerrit.wikimedia.org/r/mediawiki/extensions/Lockdown.git REL1_44 extension
-WikiForum https://gerrit.wikimedia.org/r/mediawiki/extensions/WikiForum.git master extension
 ConfirmAccount https://gerrit.wikimedia.org/r/mediawiki/extensions/ConfirmAccount.git REL1_44 extension
 MWAssistant https://github.com/labki-org/MWAssistant.git main extension
 SemanticSchemas https://github.com/labki-org/SemanticSchemas.git feature/dispatcher-bakes-display-schema extension

--- a/mediawiki/README.md
+++ b/mediawiki/README.md
@@ -65,8 +65,10 @@ workaround, etc.).
 This file is skipped at startup when `MW_DISABLE_PLATFORM_EXTENSIONS=1`
 is set in the environment — used during clean-slate extension testing.
 
-Ordering matters: ConfirmEdit must come before WikiForum/ConfirmAccount.
-The header comment in the file flags the constraint.
+Ordering matters: ConfirmEdit must come before ConfirmAccount so the
+captcha trigger settings are picked up when ConfirmAccount registers
+its account-request form. The header comment in the file flags the
+constraint.
 
 ### `skins.platform.php` — curated skins
 

--- a/mediawiki/extensions.platform.php
+++ b/mediawiki/extensions.platform.php
@@ -91,7 +91,7 @@ $wgDefaultUserOptions['discussiontools-visualenhancements'] = 1;
 $wgResourceModules['ext.labki.forum'] = [
     'styles'         => [ 'resources/styles/labki-forum.less' ],
     'scripts'        => [ 'resources/scripts/labki-forum.js' ],
-    'dependencies'   => [ 'mediawiki.util', 'mediawiki.Title', 'mediawiki.notify' ],
+    'dependencies'   => [ 'mediawiki.util', 'mediawiki.Title', 'mediawiki.notification' ],
     'localBasePath'  => $IP,
     'remoteBasePath' => $wgResourceBasePath,
 ];

--- a/mediawiki/extensions.platform.php
+++ b/mediawiki/extensions.platform.php
@@ -63,63 +63,168 @@ $wgVisualEditorSupportedSkins[] = 'tweeki';
 wfLoadExtension('DiscussionTools');
 
 // --- Labki Forum: forum-style discussion topics on top of DiscussionTools ---
-//
-// Drop a "new topic" entry point on any page. Two equivalent ways:
-//
-//   * Bundled look (uses the styling shipped in labki-forum.less):
-//     <span class="labki-forum-new-post-btn" role="button" tabindex="0">Make new post</span>
-//
-//   * Bring your own UI (any element with the data attribute is a hook):
-//     <button class="my-button" data-labki-forum-new-post>Start a discussion</button>
-//
-// On click, labki-forum.js derives the talk-namespace counterpart of the
-// current page (e.g. Forum:Miniscopes -> Forum_talk:Miniscopes), generates
-// a <UTC-timestamp>_<username> slug, and sends the user to the DT new-
-// topic widget at action=edit&section=new on that fresh subpage.
-//
-// labki-forum.less also tags Talk-namespace subpages (.labki-forum-topic
-// on <html>) so they render as forum cards: outer frame, accent-bar first
-// post, indented reply cards, button-styled reply links, and the
-// page-title bar / TOC / DT page-frame chrome hidden as redundant on a
-// single-topic-per-page layout.
-//
-// Enables DT's visual enhancements default-on so the section bar (comment
-// count + latest activity) renders without per-user opt-in.
+// See resources/scripts/labki-forum.js for the click-handler entry points
+// and resources/styles/labki-forum.less for the topic-page styling.
+
 $wgDiscussionTools_visualenhancements = 'available';
 $wgDefaultUserOptions['discussiontools-visualenhancements'] = 1;
 
-$wgResourceModules['ext.labki.forum'] = [
-    'styles'         => [ 'resources/styles/labki-forum.less' ],
-    'scripts'        => [ 'resources/scripts/labki-forum.js' ],
-    'dependencies'   => [ 'mediawiki.util', 'mediawiki.Title', 'mediawiki.notification' ],
-    'localBasePath'  => $IP,
-    'remoteBasePath' => $wgResourceBasePath,
-];
-// Split into two modules so the styles can be loaded synchronously in
-// <head> (avoiding FOUC) while the click handler stays async.
+// Split modules: styles via addModuleStyles land in a synchronous <head>
+// <link>, eliminating FOUC on first paint; the click handler can load async.
 $wgResourceModules['ext.labki.forum.styles'] = [
     'styles'         => [ 'resources/styles/labki-forum.less' ],
     'localBasePath'  => $IP,
     'remoteBasePath' => $wgResourceBasePath,
 ];
+$wgResourceModules['ext.labki.forum'] = [
+    'scripts'        => [ 'resources/scripts/labki-forum.js' ],
+    'dependencies'   => [ 'mediawiki.util', 'mediawiki.Title', 'mediawiki.notification' ],
+    'localBasePath'  => $IP,
+    'remoteBasePath' => $wgResourceBasePath,
+];
+
+// Register custom SMW properties for forum topic pages so #ask queries can
+// build a forum-style index (subject, OP, comment count, participants).
+//
+// Adding a property here is a schema change for the SQL store: existing
+// installs must run `php extensions/SemanticMediaWiki/maintenance/setupStore.php`
+// once after deploy, then `rebuildData.php -n <ns>` to backfill saved pages.
+$wgHooks['SMW::Property::initProperties'][] = static function ( $propertyRegistry ) {
+    $propertyRegistry->registerProperty( '___forum_subject',      '_txt', 'Topic subject' );
+    $propertyRegistry->registerProperty( '___forum_starter',      '_wpg', 'Topic starter' );
+    $propertyRegistry->registerProperty( '___forum_comments',     '_num', 'Comment count' );
+    $propertyRegistry->registerProperty( '___forum_participants', '_num', 'Participant count' );
+    return true;
+};
+
+// On forum topic pages, populate forum metadata: Topic subject (first H2),
+// Topic starter (first signature author), Comment count (signed comments),
+// Participant count (unique authors). Also mirror the subject into
+// DISPLAYTITLE so browser tabs and inbound wikilinks render the human-
+// readable subject instead of the <UTC>_<user> slug.
+//
+// === Why ParserAfterParse, not ContentAlterParserOutput ===
+// SMW's ParserAfterTidy reads page properties (e.g. displaytitle) before
+// the Content layer fires; ParserAfterParse runs earlier in the parser
+// pipeline and gets the values into ParserOutput in time for SMW.
+//
+// === Caveats / known limits ===
+// 1. English-locale only. Comments are detected by counting "(UTC)"
+//    signature timestamps; authors by counting [[User:Name]] wikilinks.
+//    Localized signatures (e.g. "(MEZ)" on de.wiki, "(コメント)" patterns)
+//    will undercount. Acceptable for an English-language dev wiki; revisit
+//    if this ships to a multilingual deployment.
+// 2. Counts include the OP — a fresh topic with no replies reads as
+//    "1 comment, 1 participant", matching Discourse-style conventions.
+//    If a strict "replies" count is wanted, subtract 1.
+// 3. DT has authoritative APIs (ContentHeadingItem::getCommentCount,
+//    getAuthorsBelow) that handle locale and edge cases correctly, but
+//    they need DT's CommentParser to run on already-parsed HTML, which
+//    isn't available at this hook. Migrating to those would mean a
+//    deferred-update model (job-queue annotation after page render),
+//    significantly more code for marginal accuracy gain at our scale.
+// 4. Wikitext is pulled from the revision rather than the $text param
+//    because $text at ParserAfterParse is half-parsed (strip markers
+//    in, link-rendering pending) — neither wikitext nor HTML regex
+//    matches reliably against it.
+$wgHooks['ParserAfterParse'][] = static function ( $parser, &$text, $stripState ) {
+    $title = $parser->getTitle();
+    if ( !$title || ( $title->getNamespace() % 2 ) !== 1
+        || strpos( $title->getDBkey(), '/' ) === false
+    ) {
+        return;
+    }
+    $parserOutput = $parser->getOutput();
+
+    $sections = $parserOutput->getSections();
+    $subject = $sections ? trim( strip_tags( $sections[0]['line'] ?? '' ) ) : '';
+    if ( $subject !== '' ) {
+        $parserOutput->setDisplayTitle( $subject );
+        // SMW's DisplayTitle annotator hijacks the sortkey to the displaytitle
+        // when no explicit defaultsort is set, breaking LIKE-pattern queries
+        // like [[~*Miniscopes/*]]. Pin defaultsort to the canonical prefixed
+        // title so subpage queries still resolve.
+        $parserOutput->setPageProperty( 'defaultsort', $title->getPrefixedText() );
+    }
+
+    // $text at ParserAfterParse is in a half-parsed intermediate state —
+    // strip-state markers in place, link-rendering not yet finalized — so
+    // matching either wikitext or HTML against it is unreliable. Pull the
+    // raw wikitext from the revision being parsed instead.
+    $wikitext = '';
+    $rev = $parser->getRevisionRecordObject();
+    if ( $rev ) {
+        $content = $rev->getContent( \MediaWiki\Revision\SlotRecord::MAIN );
+        if ( $content instanceof \TextContent ) {
+            $wikitext = $content->getText();
+        }
+    }
+    $commentCount = preg_match_all( '/\(UTC\)/', $wikitext );
+    preg_match_all( '/\[\[User:([^|\]\/]+)/i', $wikitext, $matches );
+    $authors = array_map( static fn( $a ) => strtolower( trim( $a ) ), $matches[1] );
+    $authors = array_values( array_filter( $authors, static fn( $a ) => $a !== '' ) );
+    $participantCount = count( array_unique( $authors ) );
+    $starter = $authors[0] ?? '';
+
+    if ( $subject === '' && $commentCount === 0 ) {
+        return;
+    }
+
+    $parserData = \SMW\Services\ServicesFactory::getInstance()->newParserData( $title, $parserOutput );
+    $semanticData = $parserData->getSemanticData();
+
+    if ( $subject !== '' ) {
+        $semanticData->addPropertyObjectValue(
+            new \SMW\DIProperty( '___forum_subject' ),
+            new \SMWDIBlob( $subject )
+        );
+    }
+    if ( $commentCount > 0 ) {
+        $semanticData->addPropertyObjectValue(
+            new \SMW\DIProperty( '___forum_comments' ),
+            new \SMWDINumber( $commentCount )
+        );
+        $semanticData->addPropertyObjectValue(
+            new \SMW\DIProperty( '___forum_participants' ),
+            new \SMWDINumber( $participantCount )
+        );
+    }
+    if ( $starter !== '' ) {
+        $starterTitle = \MediaWiki\Title\Title::makeTitleSafe( NS_USER, $starter );
+        if ( $starterTitle ) {
+            $semanticData->addPropertyObjectValue(
+                new \SMW\DIProperty( '___forum_starter' ),
+                \SMW\DIWikiPage::newFromTitle( $starterTitle )
+            );
+        }
+    }
+    $parserData->pushSemanticDataToParserOutput();
+};
 
 $wgHooks['BeforePageDisplay'][] = static function ( $out, $skin ) {
     $out->addModuleStyles( [ 'ext.labki.forum.styles' ] );
     $out->addModules( [ 'ext.labki.forum' ] );
 
-    // Pre-apply the .labki-forum-topic class on <html> via an inline
-    // head script so the CSS rules match before first paint, instead
-    // of waiting for labki-forum.js's DOM-ready handler. Talk-side
-    // namespaces have odd numeric IDs; "/" in the title indicates a
-    // subpage, i.e. a topic.
+    // Talk-side namespaces have odd numeric IDs; "/" in the DBkey
+    // indicates a subpage, i.e. a topic. Tagging server-side via
+    // addHtmlClasses lets the CSS match before first paint without
+    // an inline <script>.
     $title = $out->getTitle();
     if ( $title && ( $title->getNamespace() % 2 ) === 1
         && strpos( $title->getDBkey(), '/' ) !== false
     ) {
-        $out->addHeadItem(
-            'labki-forum-topic-init',
-            "<script>document.documentElement.classList.add('labki-forum-topic');</script>"
-        );
+        $out->addHtmlClasses( 'labki-forum-topic' );
+
+        // Breadcrumb back to the forum landing page. getRootTitle strips
+        // all subpage segments; getSubjectPage flips Forum_talk -> Forum,
+        // Talk -> Main, etc.
+        $parent = $title->getRootTitle()->getSubjectPage();
+        $linkRenderer = \MediaWiki\MediaWikiServices::getInstance()->getLinkRenderer();
+        $out->addSubtitle( $linkRenderer->makeLink(
+            $parent,
+            '← ' . $parent->getText(),
+            [ 'class' => 'labki-forum-back' ]
+        ) );
     }
 };
 

--- a/mediawiki/extensions.platform.php
+++ b/mediawiki/extensions.platform.php
@@ -1,10 +1,10 @@
 <?php
 // extensions.platform.php - Curated Platform Extensions
 //
-// Ordering note: ConfirmEdit must load before WikiForum and ConfirmAccount
-// so that captcha trigger settings are picked up when those extensions
-// register their forms. Skins are loaded in skins.platform.php (after this
-// file) and site-wide permissions live in LocalSettings.base.php.
+// Ordering note: ConfirmEdit must load before ConfirmAccount so that
+// captcha trigger settings are picked up when ConfirmAccount registers
+// its account-request form. Skins are loaded in skins.platform.php
+// (after this file) and site-wide permissions live in LocalSettings.base.php.
 
 if (!defined('MEDIAWIKI')) {
     exit;
@@ -136,15 +136,17 @@ $wgHooks['ParserAfterParse'][] = static function ( $parser, &$text, $stripState 
     }
     $parserOutput = $parser->getOutput();
 
+    // SMW's DisplayTitle annotator hijacks the sortkey to the displaytitle
+    // when no explicit defaultsort is set, breaking LIKE-pattern queries
+    // like [[~*Miniscopes/*]]. Pin defaultsort unconditionally on forum
+    // topic pages so subpage queries always resolve, regardless of whether
+    // an H2 has been added yet.
+    $parserOutput->setPageProperty( 'defaultsort', $title->getPrefixedText() );
+
     $sections = $parserOutput->getSections();
     $subject = $sections ? trim( strip_tags( $sections[0]['line'] ?? '' ) ) : '';
     if ( $subject !== '' ) {
         $parserOutput->setDisplayTitle( $subject );
-        // SMW's DisplayTitle annotator hijacks the sortkey to the displaytitle
-        // when no explicit defaultsort is set, breaking LIKE-pattern queries
-        // like [[~*Miniscopes/*]]. Pin defaultsort to the canonical prefixed
-        // title so subpage queries still resolve.
-        $parserOutput->setPageProperty( 'defaultsort', $title->getPrefixedText() );
     }
 
     // $text at ParserAfterParse is in a half-parsed intermediate state —
@@ -161,10 +163,16 @@ $wgHooks['ParserAfterParse'][] = static function ( $parser, &$text, $stripState 
     }
     $commentCount = preg_match_all( '/\(UTC\)/', $wikitext );
     preg_match_all( '/\[\[User:([^|\]\/]+)/i', $wikitext, $matches );
-    $authors = array_map( static fn( $a ) => strtolower( trim( $a ) ), $matches[1] );
-    $authors = array_values( array_filter( $authors, static fn( $a ) => $a !== '' ) );
-    $participantCount = count( array_unique( $authors ) );
-    $starter = $authors[0] ?? '';
+    $rawAuthors = array_values( array_filter(
+        array_map( 'trim', $matches[1] ),
+        static fn( $a ) => $a !== ''
+    ) );
+    // Lowercase only for dedupe — MediaWiki user-page titles past the first
+    // letter are case-sensitive (alice and Alice are distinct), so the
+    // unique-count is fine on lowercased values, but the starter name has to
+    // keep its original case before flowing into Title::makeTitleSafe.
+    $participantCount = count( array_unique( array_map( 'strtolower', $rawAuthors ) ) );
+    $starter = $rawAuthors[0] ?? '';
 
     if ( $subject === '' && $commentCount === 0 ) {
         return;
@@ -241,9 +249,6 @@ $wgCaptchaTriggers['sendemail']       = false;
 $wgCaptchaTriggers['createaccount']   = true;
 $wgCaptchaTriggers['badlogin']        = true;
 $wgCaptchaTriggers['badloginperuser'] = true;
-
-wfLoadExtension('WikiForum');
-$wgWikiForumAllowAnonymous = false;
 
 wfLoadExtension('ConfirmAccount');
 

--- a/mediawiki/extensions.platform.php
+++ b/mediawiki/extensions.platform.php
@@ -95,20 +95,23 @@ $wgResourceModules['ext.labki.forum'] = [
     'localBasePath'  => $IP,
     'remoteBasePath' => $wgResourceBasePath,
 ];
+// Split into two modules so the styles can be loaded synchronously in
+// <head> (avoiding FOUC) while the click handler stays async.
+$wgResourceModules['ext.labki.forum.styles'] = [
+    'styles'         => [ 'resources/styles/labki-forum.less' ],
+    'localBasePath'  => $IP,
+    'remoteBasePath' => $wgResourceBasePath,
+];
+
 $wgHooks['BeforePageDisplay'][] = static function ( $out, $skin ) {
-    // Styles synchronously in <head>: avoids the FOUC where the page
-    // briefly renders unstyled (full-width title, paragraphs without the
-    // accent stripe) before the async-loaded CSS module arrives.
-    $out->addModuleStyles( [ 'ext.labki.forum' ] );
-    // Scripts async — the click handler doesn't need to be present at
-    // first paint, only when the user actually interacts.
+    $out->addModuleStyles( [ 'ext.labki.forum.styles' ] );
     $out->addModules( [ 'ext.labki.forum' ] );
 
     // Pre-apply the .labki-forum-topic class on <html> via an inline
     // head script so the CSS rules match before first paint, instead
-    // of waiting for labki-forum.js's DOM-ready handler. The JS still
-    // adds the class as a backstop. Talk-side namespaces have odd
-    // numeric IDs; "/" in the title indicates a subpage, i.e. a topic.
+    // of waiting for labki-forum.js's DOM-ready handler. Talk-side
+    // namespaces have odd numeric IDs; "/" in the title indicates a
+    // subpage, i.e. a topic.
     $title = $out->getTitle();
     if ( $title && ( $title->getNamespace() % 2 ) === 1
         && strpos( $title->getDBkey(), '/' ) !== false

--- a/mediawiki/extensions.platform.php
+++ b/mediawiki/extensions.platform.php
@@ -96,7 +96,28 @@ $wgResourceModules['ext.labki.forum'] = [
     'remoteBasePath' => $wgResourceBasePath,
 ];
 $wgHooks['BeforePageDisplay'][] = static function ( $out, $skin ) {
+    // Styles synchronously in <head>: avoids the FOUC where the page
+    // briefly renders unstyled (full-width title, paragraphs without the
+    // accent stripe) before the async-loaded CSS module arrives.
+    $out->addModuleStyles( [ 'ext.labki.forum' ] );
+    // Scripts async — the click handler doesn't need to be present at
+    // first paint, only when the user actually interacts.
     $out->addModules( [ 'ext.labki.forum' ] );
+
+    // Pre-apply the .labki-forum-topic class on <html> via an inline
+    // head script so the CSS rules match before first paint, instead
+    // of waiting for labki-forum.js's DOM-ready handler. The JS still
+    // adds the class as a backstop. Talk-side namespaces have odd
+    // numeric IDs; "/" in the title indicates a subpage, i.e. a topic.
+    $title = $out->getTitle();
+    if ( $title && ( $title->getNamespace() % 2 ) === 1
+        && strpos( $title->getDBkey(), '/' ) !== false
+    ) {
+        $out->addHeadItem(
+            'labki-forum-topic-init',
+            "<script>document.documentElement.classList.add('labki-forum-topic');</script>"
+        );
+    }
 };
 
 wfLoadExtension('ConfirmEdit');

--- a/mediawiki/extensions.platform.php
+++ b/mediawiki/extensions.platform.php
@@ -62,6 +62,43 @@ $wgVisualEditorSupportedSkins[] = 'tweeki';
 
 wfLoadExtension('DiscussionTools');
 
+// --- Labki Forum: forum-style discussion topics on top of DiscussionTools ---
+//
+// Drop a "new topic" entry point on any page. Two equivalent ways:
+//
+//   * Bundled look (uses the styling shipped in labki-forum.less):
+//     <span class="labki-forum-new-post-btn" role="button" tabindex="0">Make new post</span>
+//
+//   * Bring your own UI (any element with the data attribute is a hook):
+//     <button class="my-button" data-labki-forum-new-post>Start a discussion</button>
+//
+// On click, labki-forum.js derives the talk-namespace counterpart of the
+// current page (e.g. Forum:Miniscopes -> Forum_talk:Miniscopes), generates
+// a <UTC-timestamp>_<username> slug, and sends the user to the DT new-
+// topic widget at action=edit&section=new on that fresh subpage.
+//
+// labki-forum.less also tags Talk-namespace subpages (.labki-forum-topic
+// on <html>) so they render as forum cards: outer frame, accent-bar first
+// post, indented reply cards, button-styled reply links, and the
+// page-title bar / TOC / DT page-frame chrome hidden as redundant on a
+// single-topic-per-page layout.
+//
+// Enables DT's visual enhancements default-on so the section bar (comment
+// count + latest activity) renders without per-user opt-in.
+$wgDiscussionTools_visualenhancements = 'available';
+$wgDefaultUserOptions['discussiontools-visualenhancements'] = 1;
+
+$wgResourceModules['ext.labki.forum'] = [
+    'styles'         => [ 'resources/styles/labki-forum.less' ],
+    'scripts'        => [ 'resources/scripts/labki-forum.js' ],
+    'dependencies'   => [ 'mediawiki.util', 'mediawiki.Title', 'mediawiki.notify' ],
+    'localBasePath'  => $IP,
+    'remoteBasePath' => $wgResourceBasePath,
+];
+$wgHooks['BeforePageDisplay'][] = static function ( $out, $skin ) {
+    $out->addModules( [ 'ext.labki.forum' ] );
+};
+
 wfLoadExtension('ConfirmEdit');
 $wgCaptchaClass = 'SimpleCaptcha';
 

--- a/resources/scripts/labki-forum.js
+++ b/resources/scripts/labki-forum.js
@@ -1,0 +1,85 @@
+/**
+ * Labki Forum
+ *
+ * Forum-style discussion topics on top of DiscussionTools, without a
+ * dedicated forum extension. Two responsibilities:
+ *
+ *   1. New-topic click handler. Generates a slug from the current UTC
+ *      timestamp and the viewer's username, then sends them to the
+ *      corresponding Talk-namespace subpage with DT's new-topic widget
+ *      pre-opened (action=edit&section=new). Works in any namespace: on
+ *      Forum:Miniscopes the new page lands at
+ *      Forum_talk:Miniscopes/<timestamp>_<user>; on Project:Foo it lands
+ *      at Project_talk:Foo/...; etc. We derive the talk page from the
+ *      current page via mw.Title.getTalkPage() so the button has no
+ *      hard-coded base path.
+ *
+ *      Two ways to wire it up — the handler binds to either:
+ *
+ *        * .labki-forum-new-post-btn  — gives you the bundled visual
+ *          styling from labki-forum.less. The canonical "drop a button
+ *          on a page" path.
+ *        * [data-labki-forum-new-post] — pure behavioral hook with no
+ *          styling attached. Use this when you want to bring your own
+ *          button UI (Bootstrap btn, OOUI widget, hand-rolled HTML)
+ *          and only want the click behavior.
+ *
+ *   2. Tag Talk-namespace subpages with `labki-forum-topic` on <html> so
+ *      labki-forum.less can render them as forum topic cards. Talk
+ *      namespaces have odd numeric IDs in MediaWiki — combined with a
+ *      "/" in the page name (i.e., a subpage), this is a reliable
+ *      heuristic for "this is a forum topic page" without any per-page
+ *      annotation. Edge cases like Talk:Article/Archive_1 also pick up
+ *      the styling; that's an acceptable default for a forum-oriented
+ *      wiki and is opt-out via per-page CSS if a deployment needs it.
+ */
+( function () {
+	'use strict';
+
+	$( function () {
+		var ns = mw.config.get( 'wgNamespaceNumber' );
+		var pn = mw.config.get( 'wgPageName' );
+
+		if ( typeof ns === 'number' && ns % 2 === 1 && pn && pn.indexOf( '/' ) > -1 ) {
+			document.documentElement.classList.add( 'labki-forum-topic' );
+		}
+	} );
+
+	$( function () {
+		$( '.labki-forum-new-post-btn, [data-labki-forum-new-post]' ).on( 'click keypress', function ( e ) {
+			if ( e.type === 'keypress' && e.which !== 13 && e.which !== 32 ) {
+				return;
+			}
+			e.preventDefault();
+
+			var user = mw.config.get( 'wgUserName' );
+			if ( !user ) {
+				mw.notify( 'Please log in to post.' );
+				return;
+			}
+
+			var current = mw.Title.newFromText( mw.config.get( 'wgPageName' ) );
+			var talk = current ? current.getTalkPage() : null;
+			if ( !talk ) {
+				mw.notify( 'This page does not have a talk-namespace counterpart.' );
+				return;
+			}
+
+			var d = new Date();
+			var pad = function ( n ) { return String( n ).padStart( 2, '0' ); };
+			var slug = d.getUTCFullYear() + '-' +
+				pad( d.getUTCMonth() + 1 ) + '-' +
+				pad( d.getUTCDate() ) + '_' +
+				pad( d.getUTCHours() ) +
+				pad( d.getUTCMinutes() ) +
+				pad( d.getUTCSeconds() );
+
+			var path = talk.getPrefixedText() + '/' + slug + '_' + user;
+
+			location.href = mw.util.getUrl( path, {
+				action: 'edit',
+				section: 'new'
+			} );
+		} );
+	} );
+}() );

--- a/resources/scripts/labki-forum.js
+++ b/resources/scripts/labki-forum.js
@@ -1,49 +1,19 @@
 /**
- * Labki Forum
+ * Labki Forum new-topic click handler.
  *
- * Forum-style discussion topics on top of DiscussionTools, without a
- * dedicated forum extension. Two responsibilities:
+ * Binds to .labki-forum-new-post-btn (bundled styling) and to any
+ * [data-labki-forum-new-post] element (bring-your-own UI). Derives the
+ * talk-namespace counterpart of the current page via mw.Title.getTalkPage()
+ * so the button has no hard-coded base path: a click on Forum:Miniscopes
+ * lands the user at Forum_talk:Miniscopes/<UTC-timestamp>_<username> with
+ * DT's new-topic widget pre-opened.
  *
- *   1. New-topic click handler. Generates a slug from the current UTC
- *      timestamp and the viewer's username, then sends them to the
- *      corresponding Talk-namespace subpage with DT's new-topic widget
- *      pre-opened (action=edit&section=new). Works in any namespace: on
- *      Forum:Miniscopes the new page lands at
- *      Forum_talk:Miniscopes/<timestamp>_<user>; on Project:Foo it lands
- *      at Project_talk:Foo/...; etc. We derive the talk page from the
- *      current page via mw.Title.getTalkPage() so the button has no
- *      hard-coded base path.
- *
- *      Two ways to wire it up — the handler binds to either:
- *
- *        * .labki-forum-new-post-btn  — gives you the bundled visual
- *          styling from labki-forum.less. The canonical "drop a button
- *          on a page" path.
- *        * [data-labki-forum-new-post] — pure behavioral hook with no
- *          styling attached. Use this when you want to bring your own
- *          button UI (Bootstrap btn, OOUI widget, hand-rolled HTML)
- *          and only want the click behavior.
- *
- *   2. Tag Talk-namespace subpages with `labki-forum-topic` on <html> so
- *      labki-forum.less can render them as forum topic cards. Talk
- *      namespaces have odd numeric IDs in MediaWiki — combined with a
- *      "/" in the page name (i.e., a subpage), this is a reliable
- *      heuristic for "this is a forum topic page" without any per-page
- *      annotation. Edge cases like Talk:Article/Archive_1 also pick up
- *      the styling; that's an acceptable default for a forum-oriented
- *      wiki and is opt-out via per-page CSS if a deployment needs it.
+ * The .labki-forum-topic class that triggers topic-page styling is added
+ * server-side via OutputPage::addHtmlClasses (see extensions.platform.php),
+ * not here.
  */
 ( function () {
 	'use strict';
-
-	$( function () {
-		var ns = mw.config.get( 'wgNamespaceNumber' );
-		var pn = mw.config.get( 'wgPageName' );
-
-		if ( typeof ns === 'number' && ns % 2 === 1 && pn && pn.indexOf( '/' ) > -1 ) {
-			document.documentElement.classList.add( 'labki-forum-topic' );
-		}
-	} );
 
 	$( function () {
 		$( '.labki-forum-new-post-btn, [data-labki-forum-new-post]' ).on( 'click keypress', function ( e ) {

--- a/resources/styles/labki-forum.less
+++ b/resources/styles/labki-forum.less
@@ -106,7 +106,8 @@ html.labki-forum-topic {
 	   selector outranks ours by ID specificity. The code background and
 	   font-family from Tweeki still apply, keeping the code visually
 	   distinct. */
-	.mw-parser-output > pre {
+	.mw-parser-output > pre,
+	.mw-parser-output > .mw-highlight {
 		border: 0 !important;
 		border-left: 3px solid var( --border-color-progressive, #36c ) !important;
 		border-radius: 0 !important;
@@ -171,7 +172,8 @@ html.labki-forum-topic {
 		   the visual continuity. !important needed because Tweeki's ID
 		   specificity outranks ours. The code background and font from
 		   Tweeki still apply, keeping code visually distinct. */
-		dd pre {
+		dd pre,
+		dd .mw-highlight {
 			border: 0 !important;
 			border-radius: 0 !important;
 			margin: 0.25em 0 !important;
@@ -210,7 +212,10 @@ html.labki-forum-topic {
 
 	/* Don't apply reply-card chrome inside DT/VE editing surfaces — the
 	   user is composing, not reading a saved reply, so the accent stripe
-	   and tinted background read as cruft layered onto the textarea. */
+	   and tinted background read as cruft layered onto the textarea.
+	   Two forms: dd/dl *inside* the editor (some VE surfaces nest one),
+	   AND the wrapping dd that DT inserts to host the reply widget,
+	   targeted via :has() since our forum stripe lives on that parent. */
 	.ext-discussiontools-replywidget,
 	.ve-ce-surface,
 	.ve-ui-surface {
@@ -222,6 +227,15 @@ html.labki-forum-topic {
 			background: transparent !important;
 			border-radius: 0 !important;
 		}
+	}
+	#mw-content-text dd:has( .ext-discussiontools-replywidget ),
+	#mw-content-text dd:has( .ext-discussiontools-ui-replyWidget ),
+	#mw-content-text dd:has( .ve-ce-surface ) {
+		margin-left: 0 !important;
+		padding: 0 !important;
+		border: 0 !important;
+		background: transparent !important;
+		border-radius: 0 !important;
 	}
 
 	/* Reply links rendered as small bordered buttons next to each signature */

--- a/resources/styles/labki-forum.less
+++ b/resources/styles/labki-forum.less
@@ -165,6 +165,18 @@ html.labki-forum-topic {
 			margin: 0.25em 0;
 		}
 
+		/* Pre/code blocks inside a reply: same fix as first-post pre —
+		   strip Tweeki's #content-scoped 1px box border + radius so the
+		   pre flows naturally inside the reply card instead of breaking
+		   the visual continuity. !important needed because Tweeki's ID
+		   specificity outranks ours. The code background and font from
+		   Tweeki still apply, keeping code visually distinct. */
+		dd pre {
+			border: 0 !important;
+			border-radius: 0 !important;
+			margin: 0.25em 0 !important;
+		}
+
 		/* Multi-line replies (consecutive `::` lines) flow as one
 		   continuous comment card instead of fragmenting into a stack
 		   of small per-line cards. Each line is parsed as a sibling

--- a/resources/styles/labki-forum.less
+++ b/resources/styles/labki-forum.less
@@ -73,26 +73,48 @@ html.labki-forum-topic {
 		color: var( --color-subtle, #54595d );
 	}
 
-	/* First post — top-level paragraphs render as one continuous card.
-	   Per-paragraph zero margin so the left accent bar reads as a single
-	   continuous stripe; first/last get rounded corners on the outside. */
-	.mw-parser-output > p {
+	/* First post — every top-level block (paragraph, list, blockquote,
+	   pre/code) renders as part of one continuous accent-bar card. Each
+	   block has zero margin so the bar stays unbroken across types;
+	   non-pre blocks share the neutral first-post background, while
+	   <pre> keeps its own code styling and just picks up the accent. */
+	.mw-parser-output > p,
+	.mw-parser-output > ul,
+	.mw-parser-output > ol,
+	.mw-parser-output > blockquote {
 		background: var( --background-color-neutral-subtle, #f8f9fa );
 		border-left: 3px solid var( --border-color-progressive, #36c );
 		padding: 0.6em 0.85em;
-		margin: 0;
+		/* !important: Tweeki's sitewide `p { margin-bottom: 1em }` would
+		   otherwise leave a stripe-less gap between adjacent paragraphs. */
+		margin: 0 !important;
 		border-radius: 0;
 	}
+	.mw-parser-output > pre {
+		border-left: 3px solid var( --border-color-progressive, #36c );
+		margin: 0 !important;
+	}
+
+	/* Adjacent paragraphs read as one block — drop the seam padding. */
 	.mw-parser-output > p + p {
 		padding-top: 0;
 	}
-	.mw-parser-output > p:first-of-type {
+
+	/* Tighten the outer margins on the first/last block of the post so the
+	   accent stripe doesn't gain stray whitespace above or below. */
+	.mw-parser-output > p:first-of-type,
+	.mw-parser-output > ul:first-of-type,
+	.mw-parser-output > ol:first-of-type,
+	.mw-parser-output > pre:first-of-type,
+	.mw-parser-output > blockquote:first-of-type {
 		margin-top: 0.5em;
-		border-top-right-radius: 4px;
 	}
-	.mw-parser-output > p:last-of-type {
+	.mw-parser-output > p:last-of-type,
+	.mw-parser-output > ul:last-of-type,
+	.mw-parser-output > ol:last-of-type,
+	.mw-parser-output > pre:last-of-type,
+	.mw-parser-output > blockquote:last-of-type {
 		margin-bottom: 0.75em;
-		border-bottom-right-radius: 4px;
 	}
 
 	/* Replies — DT writes ":" indent which renders as <dl><dd>. Tweeki
@@ -129,6 +151,22 @@ html.labki-forum-topic {
 		}
 		dd p + p {
 			padding-top: 0.4em;
+		}
+	}
+
+	/* Don't apply reply-card chrome inside DT/VE editing surfaces — the
+	   user is composing, not reading a saved reply, so the accent stripe
+	   and tinted background read as cruft layered onto the textarea. */
+	.ext-discussiontools-replywidget,
+	.ve-ce-surface,
+	.ve-ui-surface {
+		dl,
+		dd {
+			margin: 0 !important;
+			padding: 0 !important;
+			border: 0 !important;
+			background: transparent !important;
+			border-radius: 0 !important;
 		}
 	}
 

--- a/resources/styles/labki-forum.less
+++ b/resources/styles/labki-forum.less
@@ -177,6 +177,16 @@ html.labki-forum-topic {
 			margin: 0.25em 0 !important;
 		}
 
+		/* Empty pre/p left over from MW parser quirks — e.g., wikitext
+		   like ":<pre>" / ":content" / ":</pre>" where the parser puts
+		   the open tag, content, and close tag each into separate <dd>s,
+		   leaving an empty <pre> renderable. Hiding these stops them
+		   from appearing as stray gray bars in a reply card. */
+		dd pre:empty,
+		dd p:empty {
+			display: none;
+		}
+
 		/* Multi-line replies (consecutive `::` lines) flow as one
 		   continuous comment card instead of fragmenting into a stack
 		   of small per-line cards. Each line is parsed as a sibling

--- a/resources/styles/labki-forum.less
+++ b/resources/styles/labki-forum.less
@@ -1,0 +1,154 @@
+/**
+ * Labki Forum styles
+ *
+ * Two surfaces:
+ *
+ *   1. ".labki-forum-new-post-btn" — the button users drop on a landing
+ *      page. Styled here so deployments don't need to remember the
+ *      mw-ui-button class chain.
+ *
+ *   2. "html.labki-forum-topic" — Talk-namespace subpages, tagged by
+ *      labki-forum.js. Renders the page as a forum topic card: outer
+ *      frame, accent-bar first post, indented reply cards, button-styled
+ *      reply links, hidden page-title bar / TOC / DT page-frame chrome
+ *      that's redundant on a single-topic-per-page layout.
+ *
+ * All colors use Codex / MW design tokens with hex fallbacks so the
+ * styling respects light/dark theme switching.
+ */
+
+/* === New-post button === */
+
+.labki-forum-new-post-btn {
+	display: inline-block;
+	padding: 0.4em 1em;
+	border: 1px solid var( --border-color-progressive, #36c );
+	border-radius: 4px;
+	background: var( --background-color-progressive, #36c );
+	color: #fff;
+	font-weight: 500;
+	text-decoration: none;
+	cursor: pointer;
+	user-select: none;
+
+	&:hover {
+		background: var( --background-color-progressive--hover, #447ff5 );
+		border-color: var( --border-color-progressive--hover, #447ff5 );
+		color: #fff;
+		text-decoration: none;
+	}
+}
+
+/* === Forum topic page (set by labki-forum.js on Talk-namespace subpages) === */
+
+html.labki-forum-topic {
+
+	/* Hide elements not useful in a single-topic-per-page layout */
+	#firstHeading,
+	.firstHeading,
+	#toc,
+	.toc,
+	#siteSub,
+	.mw-pt-translate-header,
+	.ext-discussiontools-init-pageframe-latestcomment,
+	[class*="pageframe-latestcomment"] {
+		display: none !important;
+	}
+
+	/* Outer card frame around the topic content */
+	.mw-parser-output {
+		border: 1px solid var( --border-color-base, #c8ccd1 );
+		border-radius: 8px;
+		padding: 1em 1.25em;
+		background: var( --background-color-base, #fff );
+		box-shadow: 0 1px 2px rgba( 0, 0, 0, 0.04 );
+	}
+
+	/* DT section bar (comment count / latest activity under the H2) */
+	.ext-discussiontools-init-section-bar {
+		border-bottom: 1px solid var( --border-color-subtle, #eaecf0 );
+		padding-bottom: 0.5em;
+		margin-bottom: 1em;
+		font-size: 0.9em;
+		color: var( --color-subtle, #54595d );
+	}
+
+	/* First post — top-level paragraphs render as one continuous card.
+	   Per-paragraph zero margin so the left accent bar reads as a single
+	   continuous stripe; first/last get rounded corners on the outside. */
+	.mw-parser-output > p {
+		background: var( --background-color-neutral-subtle, #f8f9fa );
+		border-left: 3px solid var( --border-color-progressive, #36c );
+		padding: 0.6em 0.85em;
+		margin: 0;
+		border-radius: 0;
+	}
+	.mw-parser-output > p + p {
+		padding-top: 0;
+	}
+	.mw-parser-output > p:first-of-type {
+		margin-top: 0.5em;
+		border-top-right-radius: 4px;
+	}
+	.mw-parser-output > p:last-of-type {
+		margin-bottom: 0.75em;
+		border-bottom-right-radius: 4px;
+	}
+
+	/* Replies — DT writes ":" indent which renders as <dl><dd>. Tweeki
+	   resets dd margins to 0; we re-introduce an indent and a soft card
+	   look per nesting level. !important is needed to outrank Tweeki's
+	   sitewide reset. */
+	#mw-content-text {
+
+		dl {
+			margin: 0.5em 0;
+		}
+
+		dd {
+			margin-left: 1.75em !important;
+			padding: 0.5em 0.85em;
+			border-left: 2px solid var( --border-color-muted, #d3d4d5 );
+			background: var( --background-color-neutral-subtle, #f8f9fa );
+			border-radius: 0 4px 4px 0;
+			margin-bottom: 0.5em;
+		}
+
+		dd dd {
+			margin-left: 1.25em !important;
+			background: var( --background-color-base, #fff );
+		}
+
+		dd dd dd {
+			border-left-color: var( --border-color-subtle, #eaecf0 );
+		}
+
+		/* Multi-paragraph replies stay as one continuous block within a dd */
+		dd p {
+			margin: 0;
+		}
+		dd p + p {
+			padding-top: 0.4em;
+		}
+	}
+
+	/* Reply links rendered as small bordered buttons next to each signature */
+	a.ext-discussiontools-init-replylink-reply,
+	.ext-discussiontools-init-replylink-buttons a {
+		display: inline-block;
+		padding: 0.15em 0.6em;
+		margin-left: 0.4em;
+		border: 1px solid var( --border-color-base, #c8ccd1 );
+		border-radius: 4px;
+		background: var( --background-color-interactive-subtle, #f8f9fa );
+		color: var( --color-base, #202122 ) !important;
+		font-size: 0.9em;
+		font-weight: 500;
+		text-decoration: none !important;
+
+		&:hover {
+			background: var( --background-color-interactive, #eaecf0 );
+			border-color: var( --border-color-base--hover, #a2a9b1 );
+		}
+	}
+}

--- a/resources/styles/labki-forum.less
+++ b/resources/styles/labki-forum.less
@@ -85,36 +85,35 @@ html.labki-forum-topic {
 		background: var( --background-color-neutral-subtle, #f8f9fa );
 		border-left: 3px solid var( --border-color-progressive, #36c );
 		padding: 0.6em 0.85em;
-		/* !important: Tweeki's sitewide `p { margin-bottom: 1em }` would
-		   otherwise leave a stripe-less gap between adjacent paragraphs. */
+		/* !important: Tweeki's sitewide `p { margin-bottom: 1em }` (and
+		   Bootstrap's matching ul/ol margin) would otherwise leave a
+		   stripe-less gap between adjacent first-post blocks. */
 		margin: 0 !important;
 		border-radius: 0;
 	}
+
+	/* Lists: preserve the native padding-left so bullet/number markers
+	   render inside the colored block instead of being clipped off the
+	   left edge by our own 0.85em horizontal padding. */
+	.mw-parser-output > ul,
+	.mw-parser-output > ol {
+		padding-left: 2.5em;
+	}
+
+	/* Pre/code blocks: undo Tweeki's #content-scoped 1px box-border + radius
+	   so the accent stripe stays continuous with sibling first-post blocks.
+	   The code background and font-family from Tweeki still apply, keeping
+	   the code visually distinct. */
 	.mw-parser-output > pre {
+		border: 0;
 		border-left: 3px solid var( --border-color-progressive, #36c );
+		border-radius: 0;
 		margin: 0 !important;
 	}
 
 	/* Adjacent paragraphs read as one block — drop the seam padding. */
 	.mw-parser-output > p + p {
 		padding-top: 0;
-	}
-
-	/* Tighten the outer margins on the first/last block of the post so the
-	   accent stripe doesn't gain stray whitespace above or below. */
-	.mw-parser-output > p:first-of-type,
-	.mw-parser-output > ul:first-of-type,
-	.mw-parser-output > ol:first-of-type,
-	.mw-parser-output > pre:first-of-type,
-	.mw-parser-output > blockquote:first-of-type {
-		margin-top: 0.5em;
-	}
-	.mw-parser-output > p:last-of-type,
-	.mw-parser-output > ul:last-of-type,
-	.mw-parser-output > ol:last-of-type,
-	.mw-parser-output > pre:last-of-type,
-	.mw-parser-output > blockquote:last-of-type {
-		margin-bottom: 0.75em;
 	}
 
 	/* Replies — DT writes ":" indent which renders as <dl><dd>. Tweeki

--- a/resources/styles/labki-forum.less
+++ b/resources/styles/labki-forum.less
@@ -1,20 +1,9 @@
 /**
- * Labki Forum styles
+ * Labki Forum styles. Two surfaces: the .labki-forum-new-post-btn entry
+ * point, and html.labki-forum-topic (set server-side on Talk-namespace
+ * subpages) which restyles the page as a single-topic forum card.
  *
- * Two surfaces:
- *
- *   1. ".labki-forum-new-post-btn" — the button users drop on a landing
- *      page. Styled here so deployments don't need to remember the
- *      mw-ui-button class chain.
- *
- *   2. "html.labki-forum-topic" — Talk-namespace subpages, tagged by
- *      labki-forum.js. Renders the page as a forum topic card: outer
- *      frame, accent-bar first post, indented reply cards, button-styled
- *      reply links, hidden page-title bar / TOC / DT page-frame chrome
- *      that's redundant on a single-topic-per-page layout.
- *
- * All colors use Codex / MW design tokens with hex fallbacks so the
- * styling respects light/dark theme switching.
+ * Colors use Codex tokens with hex fallbacks so light/dark theming works.
  */
 
 /* === New-post button === */
@@ -50,9 +39,24 @@ html.labki-forum-topic {
 	.toc,
 	#siteSub,
 	.mw-pt-translate-header,
-	.ext-discussiontools-init-pageframe-latestcomment,
-	[class*="pageframe-latestcomment"] {
+	.ext-discussiontools-init-pageframe-latestcomment {
 		display: none !important;
+	}
+
+	/* Breadcrumb back-link to the forum landing page, populated by
+	   addSubtitle in extensions.platform.php. Sits in #contentSub above
+	   the topic card. */
+	.labki-forum-back {
+		display: inline-block;
+		margin-bottom: 0.5em;
+		color: var( --color-subtle, #54595d );
+		font-size: 0.95em;
+		text-decoration: none;
+
+		&:hover {
+			color: var( --color-progressive--hover, #447ff5 );
+			text-decoration: underline;
+		}
 	}
 
 	/* Outer card frame around the topic content */

--- a/resources/styles/labki-forum.less
+++ b/resources/styles/labki-forum.less
@@ -154,6 +154,17 @@ html.labki-forum-topic {
 			padding-top: 0.4em;
 		}
 
+		/* Bullet/number lists inside a reply: trim browser's default
+		   ~40px padding-left so the marker doesn't end up pushed far
+		   past the surrounding reply text. The reply card's own
+		   horizontal padding already provides the inset; we just need
+		   enough room for the list marker itself. */
+		dd ul,
+		dd ol {
+			padding-left: 1.5em;
+			margin: 0.25em 0;
+		}
+
 		/* Multi-line replies (consecutive `::` lines) flow as one
 		   continuous comment card instead of fragmenting into a stack
 		   of small per-line cards. Each line is parsed as a sibling

--- a/resources/styles/labki-forum.less
+++ b/resources/styles/labki-forum.less
@@ -102,12 +102,14 @@ html.labki-forum-topic {
 
 	/* Pre/code blocks: undo Tweeki's #content-scoped 1px box-border + radius
 	   so the accent stripe stays continuous with sibling first-post blocks.
-	   The code background and font-family from Tweeki still apply, keeping
-	   the code visually distinct. */
+	   !important on the borders is needed because Tweeki's `#content pre`
+	   selector outranks ours by ID specificity. The code background and
+	   font-family from Tweeki still apply, keeping the code visually
+	   distinct. */
 	.mw-parser-output > pre {
-		border: 0;
-		border-left: 3px solid var( --border-color-progressive, #36c );
-		border-radius: 0;
+		border: 0 !important;
+		border-left: 3px solid var( --border-color-progressive, #36c ) !important;
+		border-radius: 0 !important;
 		margin: 0 !important;
 	}
 
@@ -150,6 +152,26 @@ html.labki-forum-topic {
 		}
 		dd p + p {
 			padding-top: 0.4em;
+		}
+
+		/* Multi-line replies (consecutive `::` lines) flow as one
+		   continuous comment card instead of fragmenting into a stack
+		   of small per-line cards. Each line is parsed as a sibling
+		   <dd> within one <dl>, so we drop intra-group margins and
+		   only round the outer corners of the group. */
+		dl > dd {
+			margin-bottom: 0;
+			border-radius: 0;
+		}
+		dl > dd + dd {
+			padding-top: 0;
+		}
+		dl > dd:last-child {
+			border-bottom-right-radius: 4px;
+			margin-bottom: 0.5em;
+		}
+		dl > dd:first-child {
+			border-top-right-radius: 4px;
 		}
 	}
 

--- a/scripts/probe-config.php
+++ b/scripts/probe-config.php
@@ -48,6 +48,29 @@ class LabkiProbeConfig extends Maintenance {
         }
         $extNames = array_values( array_unique( $extNames ) );
         echo 'EXTENSIONS=' . implode( ',', $extNames ) . "\n";
+
+        // Namespace IDs registered by the dev overlay (Forum=3000,
+        // Forum_talk=3001) so the smoke test can verify the bind-mount
+        // landed and namespace registration didn't collide.
+        $nsInfo = MediaWiki\MediaWikiServices::getInstance()->getNamespaceInfo();
+        $nsIds = array_keys( $nsInfo->getCanonicalNamespaces() );
+        sort( $nsIds );
+        echo 'NAMESPACES=' . implode( ',', $nsIds ) . "\n";
+
+        // Custom SMW properties registered by the labki-forum module. The
+        // PropertyRegistry returns null for unknown IDs; filter for the
+        // ones that actually registered. Guard against SMW being absent
+        // (extensions disabled mode) so this probe stays useful there too.
+        $forumProps = [];
+        if ( class_exists( '\\SMW\\PropertyRegistry' ) ) {
+            $reg = \SMW\PropertyRegistry::getInstance();
+            foreach ( [ '___forum_subject', '___forum_starter', '___forum_comments', '___forum_participants' ] as $pid ) {
+                if ( $reg->getPropertyValueTypeById( $pid ) !== null ) {
+                    $forumProps[] = $pid;
+                }
+            }
+        }
+        echo 'SMW_FORUM_PROPS=' . implode( ',', $forumProps ) . "\n";
     }
 }
 

--- a/scripts/probe-config.php
+++ b/scripts/probe-config.php
@@ -59,10 +59,13 @@ class LabkiProbeConfig extends Maintenance {
 
         // Custom SMW properties registered by the labki-forum module. The
         // PropertyRegistry returns null for unknown IDs; filter for the
-        // ones that actually registered. Guard against SMW being absent
-        // (extensions disabled mode) so this probe stays useful there too.
+        // ones that actually registered. Use ExtensionRegistry::isLoaded
+        // rather than class_exists — SMW is composer-autoloaded so its
+        // classes are always discoverable, but in disabled-extensions mode
+        // wfLoadExtension never ran and SMW's bootstrap globals are unset,
+        // making PropertyRegistry::getInstance() throw on $smwgServicesFileDir.
         $forumProps = [];
-        if ( class_exists( '\\SMW\\PropertyRegistry' ) ) {
+        if ( ExtensionRegistry::getInstance()->isLoaded( 'SemanticMediaWiki' ) ) {
             $reg = \SMW\PropertyRegistry::getInstance();
             foreach ( [ '___forum_subject', '___forum_starter', '___forum_comments', '___forum_participants' ] as $pid ) {
                 if ( $reg->getPropertyValueTypeById( $pid ) !== null ) {

--- a/scripts/probe-forum-page.php
+++ b/scripts/probe-forum-page.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * probe-forum-page.php - end-to-end smoke probe for the labki-forum hooks.
+ *
+ * Saves a synthetic Forum_talk subpage with a known wikitext shape (which
+ * triggers the ParserAfterParse hook on the saved revision), then reads
+ * back what landed in MediaWiki's parser output and SMW's store. Prints
+ * KEY=value lines reporting:
+ *
+ *   DISPLAYTITLE       - first H2 promoted via setDisplayTitle
+ *   DEFAULTSORT        - canonical title pinned to neutralize SMW's
+ *                        sortkey hijack from the DisplayTitle annotator
+ *   FORUM_COMMENTS     - count of (UTC) signature timestamps in wikitext
+ *   FORUM_PARTICIPANTS - unique [[User:X]] authors
+ *   FORUM_STARTER      - first author, as User:Name
+ *   FORUM_SUBJECT      - same string as DISPLAYTITLE, captured separately
+ *                        through SMW's custom property channel
+ *
+ * The hook reads wikitext via $parser->getRevisionRecordObject(), so an
+ * in-memory Parser::parse() (no revision) doesn't exercise the SMW path.
+ * Saving via PageUpdater is the realistic flow that mirrors what happens
+ * when a real user creates a topic.
+ *
+ * Skips gracefully (exit 0, prints SKIP=...) when run on a target that
+ * doesn't have the Forum_talk namespace registered (i.e. the prod CI matrix
+ * row, where the dev-config overlay isn't mounted).
+ *
+ * The page is saved into the test database, which is torn down by
+ * `docker compose down -v` at the end of the smoke run — no cleanup needed.
+ */
+
+require_once '/var/www/html/maintenance/Maintenance.php';
+
+use MediaWiki\CommentStore\CommentStoreComment;
+use MediaWiki\MediaWikiServices;
+use MediaWiki\Revision\SlotRecord;
+use MediaWiki\Title\Title;
+use MediaWiki\User\User;
+
+class LabkiProbeForumPage extends Maintenance {
+    public function __construct() {
+        parent::__construct();
+        $this->addDescription( 'Probe the labki-forum hooks via a saved Forum_talk subpage.' );
+    }
+
+    public function execute() {
+        if ( !defined( 'NS_FORUM_TALK' ) ) {
+            echo "SKIP=NS_FORUM_TALK not registered (run on dev target only)\n";
+            return;
+        }
+
+        $title = Title::makeTitle(
+            NS_FORUM_TALK,
+            'Smoketest/2026-01-01_120000_Bob'
+        );
+
+        // Two unique authors across three signed comments. 'Bob' uses
+        // mixed case so a case-folding regression in the starter extraction
+        // would surface as User:bob (or a redlink) rather than User:Bob.
+        $wikitext = "== Hello smoke ==\n\n"
+            . "Initial post body. [[User:Bob|Bob]] ([[User talk:Bob|talk]]) 12:00, 1 January 2026 (UTC)\n\n"
+            . ":Reply from another user. [[User:Alice|Alice]] ([[User talk:Alice|talk]]) 12:05, 1 January 2026 (UTC)\n\n"
+            . "::Followup. [[User:Bob|Bob]] ([[User talk:Bob|talk]]) 12:10, 1 January 2026 (UTC)\n";
+
+        $services = MediaWikiServices::getInstance();
+        $user = User::newSystemUser( 'Smoke probe', [ 'steal' => true ] );
+        $page = $services->getWikiPageFactory()->newFromTitle( $title );
+
+        $updater = $page->newPageUpdater( $user );
+        $updater->setContent( SlotRecord::MAIN, new WikitextContent( $wikitext ) );
+        $rev = $updater->saveRevision(
+            CommentStoreComment::newUnsavedComment( 'smoke probe' )
+        );
+        if ( !$rev ) {
+            $this->fatalError( 'Failed to save smoke-probe revision: '
+                . $updater->getStatus()->getWikiText( false, false, 'en' ) );
+        }
+
+        // Force a fresh parse so the hook re-runs against the saved revision
+        // (the parser cache may already hold a render from a prior smoke run).
+        $popts = ParserOptions::newFromAnon();
+        $popts->setRenderReason( 'smoke-probe' );
+        $parserOutput = $page->getParserOutput( $popts ) ?: $page->getParserOutput();
+
+        echo 'DISPLAYTITLE=' . ( $parserOutput ? $parserOutput->getDisplayTitle() : '' ) . "\n";
+        echo 'DEFAULTSORT='
+            . ( $parserOutput ? ( $parserOutput->getPageProperty( 'defaultsort' ) ?? '' ) : '' )
+            . "\n";
+
+        // SMW persists semantic data via its own hooks during the save flow,
+        // so reading from the store gives the authoritative view of what the
+        // labki-forum hooks contributed.
+        $store = \SMW\StoreFactory::getStore();
+        $smwData = $store->getSemanticData( \SMW\DIWikiPage::newFromTitle( $title ) );
+
+        $columns = [
+            'FORUM_SUBJECT'      => '___forum_subject',
+            'FORUM_STARTER'      => '___forum_starter',
+            'FORUM_COMMENTS'     => '___forum_comments',
+            'FORUM_PARTICIPANTS' => '___forum_participants',
+        ];
+        foreach ( $columns as $key => $pid ) {
+            $vals = $smwData->getPropertyValues( new \SMW\DIProperty( $pid ) );
+            if ( !$vals ) {
+                echo "$key=\n";
+                continue;
+            }
+            $first = reset( $vals );
+            if ( $first instanceof \SMWDINumber ) {
+                echo "$key=" . (int)$first->getNumber() . "\n";
+            } elseif ( $first instanceof \SMWDIBlob ) {
+                echo "$key=" . $first->getString() . "\n";
+            } elseif ( $first instanceof \SMW\DIWikiPage ) {
+                $t = $first->getTitle();
+                echo "$key=" . ( $t ? $t->getPrefixedText() : '' ) . "\n";
+            } else {
+                echo "$key=" . (string)$first . "\n";
+            }
+        }
+    }
+}
+
+$maintClass = LabkiProbeForumPage::class;
+require_once RUN_MAINTENANCE_IF_MAIN;


### PR DESCRIPTION
## Summary
- Bundles a small ResourceLoader module (`ext.labki.forum`) that lets any page act as a forum landing page — drop the button HTML, click, land on a fresh `Talk_NS:Page/<UTC-timestamp>_<user>` topic with DT's new-topic widget pre-opened. The button uses `mw.Title.getTalkPage()` to derive its target, so it works in any namespace (Forum: → Forum_talk:, Project: → Project talk:, etc.).
- Tags Talk-namespace subpages with `html.labki-forum-topic` so bundled styles render them as forum topic cards (outer frame, accent-bar first post, indented `<dd>` reply cards, button-styled reply links). Hides the page-title bar / TOC / DT page-frame chrome that's redundant on a single-topic-per-page layout.
- Two button patterns supported: `<span class="labki-forum-new-post-btn">` for the bundled look, or `<button data-labki-forum-new-post>` as a behavior-only hook for any custom UI.
- Turns DT's visual enhancements default-on (`$wgDiscussionTools_visualenhancements = 'available'`) so the section bar appears without per-user opt-in.
- Wires the dev compose with a `/mw-config` mount and a `compose/dev-config/LocalSettings.user.php` overlay declaring a `Forum (3000)` / `Forum_talk (3001)` namespace pair so the forum is testable end-to-end out of the box. Forum: is sysop-only; Forum_talk: inherits standard talk-namespace edit rights.

## Test plan
- [ ] `docker compose -f compose/docker-compose.dev.yml up -d --build` brings up the dev wiki cleanly
- [ ] `Special:Allpages` shows `Forum` and `Forum talk` in the namespace dropdown
- [ ] As sysop, create `Forum:Miniscopes` containing the `<span class="labki-forum-new-post-btn" role="button" tabindex="0">Make new post</span>` button + an SMW `#ask` query for the topic list
- [ ] Click the button → land on `Forum_talk:Miniscopes/<UTC-timestamp>_<sysop>?action=edit&section=new` with DT's new-topic widget pre-opened
- [ ] Submit a topic → page renders with the card frame, hidden first-heading/TOC, button-styled reply links
- [ ] Reply to the topic, then reply-to-reply → second-level nesting indents visibly with its own reply card
- [ ] Drop the same button on a `Project:` page → click routes to `Project talk:.../<slug>` (proves namespace generalization)
- [ ] Use the `<button data-labki-forum-new-post>` variant on a fresh page → behaves identically without picking up the bundled button styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)