### PR TITLE
Forum: Comment count works on non-UTC wikis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Theme stylesheet refactored from a single `labki-tweeki.css` into a Citizen-style trio: `labki-tweeki.less` (rules) + `tokens-theme-base.less` (light tokens) + `tokens-theme-dark.less` (dark tokens + Codex mirror). Tokens are declared in OKLCH for perceptual uniformity; the dark theme overrides only lightness values so the palette is a parametric mirror of the light palette rather than a hand-tuned alternative. SchemaSync TemplateStyles already consume `var(--labki-*)` with literal fallbacks, so this is a backing change with no template-side migration.
 - `compose/docker-compose.dev.yml` now also live-mounts `mediawiki/` so edits to platform PHP config (skins.platform.php, extensions.platform.php, LocalSettings.base.php) take effect without an image rebuild.
 
+### Fixed
+- **Labki Forum — `Comment count` / `Participant count` on non-UTC wikis**: the `ParserAfterParse` annotator was matching the literal string `(UTC)` to count signed comments, so wikis configured with a non-UTC `$wgLocaltimezone` (signatures end in `(PDT)` / `(PST)` / `(EST)` / etc.) saw `Comment count = 0` and no `Participant count` annotation — leaving the forum-index `?Comment count=Replies` column stuck at 0 even on active topics. The regex now matches the full MW English-locale signature timestamp shape (`HH:MM, D MONTHNAME YYYY (TZ)`) with an open-ended TZ token, so any locale-time-zone setting counts correctly. Existing topic pages need a null-edit (or `rebuildData.php -n 3000,3001`) for the annotation to backfill.
+
 ### Removed
 - Timestamp-localization JavaScript in `labki-tweeki.js`. The string-rewrite was overriding MediaWiki user date preferences with a hardcoded format. Date display now defers to SMW query authors (`?Date`, `?Date#-F[...]`) and MediaWiki preferences.
 - `--labki-warning` and `--labki-radius` design tokens — defined but unreferenced anywhere in the codebase.

--- a/ci/smoke-test.sh
+++ b/ci/smoke-test.sh
@@ -191,8 +191,8 @@ if [ "$DOCKER_TARGET" = "dev" ] && [ "$EXTENSIONS_MODE" = "enabled" ]; then
         || fail "DEFAULTSORT is '$(fextract DEFAULTSORT)', expected canonical title (SMW sortkey hijack regression)."
     [ "$(fextract FORUM_SUBJECT)" = "Hello smoke" ] \
         || fail "FORUM_SUBJECT SMW property is '$(fextract FORUM_SUBJECT)', expected 'Hello smoke'."
-    [ "$(fextract FORUM_COMMENTS)" = "3" ] \
-        || fail "FORUM_COMMENTS is '$(fextract FORUM_COMMENTS)', expected 3 (one per (UTC) signature)."
+    [ "$(fextract FORUM_COMMENTS)" = "4" ] \
+        || fail "FORUM_COMMENTS is '$(fextract FORUM_COMMENTS)', expected 4 (three UTC + one PDT signature; locale-time-zone regression in the signature regex?)."
     [ "$(fextract FORUM_PARTICIPANTS)" = "2" ] \
         || fail "FORUM_PARTICIPANTS is '$(fextract FORUM_PARTICIPANTS)', expected 2 unique authors."
     [ "$(fextract FORUM_STARTER)" = "User:Bob" ] \

--- a/docs/labki-forum.md
+++ b/docs/labki-forum.md
@@ -13,7 +13,7 @@ Bundled into the platform with no extra configuration beyond namespace setup:
 - **Five custom SMW properties** populated per topic so a landing page can render a forum index via `#ask`:
   - `Topic subject` (Text) — first H2 of the page
   - `Topic starter` (Page) — first signature author, as a `User:Name` link
-  - `Comment count` (Number) — count of signed `(UTC)` timestamps
+  - `Comment count` (Number) — count of signed timestamps in the page; matches any `$wgLocaltimezone` (UTC, PDT/PST, EST/EDT, etc.)
   - `Participant count` (Number) — unique authors
   - `Has forum` (Page) — the topic's containing forum landing, derived from the page's base title (`Forum_talk:Hardware/<slug>` → `Forum:Hardware`). Always set, even on freshly-saved empty topics. Enables chained queries like `[[Has forum.Has parent forum::Forum:Home]]` for activity feeds on hub-style landing pages.
 
@@ -129,7 +129,7 @@ The styling sits behind two top-level hooks you can override via `MediaWiki:Comm
 
 ### English-locale signature heuristic
 
-`Comment count` and `Participant count` are extracted by counting `(UTC)` timestamps and `[[User:Name]]` wikilinks in the saved revision's wikitext. Localized signatures (`(MEZ)` on de.wiki, etc.) will undercount. Switching to DT's authoritative `ContentHeadingItem::getCommentCount()` would require a deferred-update model since DT's parser needs already-rendered HTML. Acceptable for English-language deployments; revisit if shipping to a multilingual wiki.
+`Comment count` and `Participant count` are extracted from the saved revision's wikitext: comments by matching the MW English-locale signature timestamp shape (`HH:MM, D MONTHNAME YYYY (TZ)`), participants by counting `[[User:Name]]` wikilinks. The TZ token is open-ended, so non-UTC `$wgLocaltimezone` settings (`(PDT)`, `(PST)`, `(EST)`, …) count correctly. Fully-localized signatures with non-English month names will still undercount. Switching to DT's authoritative `ContentHeadingItem::getCommentCount()` would require a deferred-update model since DT's parser needs already-rendered HTML. Acceptable for English-language deployments; revisit if shipping to a multilingual wiki.
 
 ### Counts include the OP
 

--- a/mediawiki/extensions.platform.php
+++ b/mediawiki/extensions.platform.php
@@ -121,10 +121,13 @@ $wgHooks['SMW::Property::initProperties'][] = static function ( $propertyRegistr
 // pipeline and gets the values into ParserOutput in time for SMW.
 //
 // === Caveats / known limits ===
-// 1. English-locale only. Comments are detected by counting "(UTC)"
-//    signature timestamps; authors by counting [[User:Name]] wikilinks.
-//    Localized signatures (e.g. "(MEZ)" on de.wiki, "(コメント)" patterns)
-//    will undercount. Acceptable for an English-language dev wiki; revisit
+// 1. English-locale only. Comments are detected by matching the MW
+//    English-locale signature timestamp shape (HH:MM, D MONTHNAME YYYY
+//    (TZ)); authors by counting [[User:Name]] wikilinks. The TZ token
+//    is open-ended, so any $wgLocaltimezone — UTC, PDT/PST, EST/EDT,
+//    CET, etc. — is picked up. Non-Latin month names (e.g. "(コメント)"
+//    patterns, fully localized DateFormatter output) will still
+//    undercount. Acceptable for English-language deployments; revisit
 //    if this ships to a multilingual deployment.
 // 2. Counts include the OP — a fresh topic with no replies reads as
 //    "1 comment, 1 participant", matching Discourse-style conventions.
@@ -173,7 +176,16 @@ $wgHooks['ParserAfterParse'][] = static function ( $parser, &$text, $stripState 
             $wikitext = $content->getText();
         }
     }
-    $commentCount = preg_match_all( '/\(UTC\)/', $wikitext );
+    // Match the full MW English-locale signature timestamp shape
+    // (`HH:MM, D MONTHNAME YYYY (TZ)`) rather than just `(UTC)`, so wikis
+    // configured with a non-UTC $wgLocaltimezone (signatures ending in PDT
+    // / PST / EST / etc.) count their comments. Anchoring on the timestamp
+    // pattern keeps the TZ token open-ended without false-positiving on
+    // unrelated parenthetical text.
+    $commentCount = preg_match_all(
+        '/\d{1,2}:\d{2},\s\d{1,2}\s\S+\s\d{4}\s\([^)]+\)/u',
+        $wikitext
+    );
     preg_match_all( '/\[\[User:([^|\]\/]+)/i', $wikitext, $matches );
     $rawAuthors = array_values( array_filter(
         array_map( 'trim', $matches[1] ),

--- a/scripts/probe-forum-page.php
+++ b/scripts/probe-forum-page.php
@@ -10,7 +10,8 @@
  *   DISPLAYTITLE       - first H2 promoted via setDisplayTitle
  *   DEFAULTSORT        - canonical title pinned to neutralize SMW's
  *                        sortkey hijack from the DisplayTitle annotator
- *   FORUM_COMMENTS     - count of (UTC) signature timestamps in wikitext
+ *   FORUM_COMMENTS     - count of MW signature timestamps in wikitext
+ *                        (locale-time-zone agnostic: (UTC), (PDT), (EST), …)
  *   FORUM_PARTICIPANTS - unique [[User:X]] authors
  *   FORUM_STARTER      - first author, as User:Name
  *   FORUM_SUBJECT      - same string as DISPLAYTITLE, captured separately
@@ -54,13 +55,17 @@ class LabkiProbeForumPage extends Maintenance {
             'Smoketest/2026-01-01_120000_Bob'
         );
 
-        // Two unique authors across three signed comments. 'Bob' uses
+        // Two unique authors across four signed comments. 'Bob' uses
         // mixed case so a case-folding regression in the starter extraction
         // would surface as User:bob (or a redlink) rather than User:Bob.
+        // The final reply uses a (PDT) timestamp so the signature regex's
+        // locale-time-zone openness is exercised — a regression back to a
+        // literal `(UTC)` match would drop the count to 3.
         $wikitext = "== Hello smoke ==\n\n"
             . "Initial post body. [[User:Bob|Bob]] ([[User talk:Bob|talk]]) 12:00, 1 January 2026 (UTC)\n\n"
             . ":Reply from another user. [[User:Alice|Alice]] ([[User talk:Alice|talk]]) 12:05, 1 January 2026 (UTC)\n\n"
-            . "::Followup. [[User:Bob|Bob]] ([[User talk:Bob|talk]]) 12:10, 1 January 2026 (UTC)\n";
+            . "::Followup. [[User:Bob|Bob]] ([[User talk:Bob|talk]]) 12:10, 1 January 2026 (UTC)\n\n"
+            . ":Non-UTC reply. [[User:Bob|Bob]] ([[User talk:Bob|talk]]) 05:15, 1 January 2026 (PDT)\n";
 
         $services = MediaWikiServices::getInstance();
         $user = User::newSystemUser( 'Smoke probe', [ 'steal' => true ] );


### PR DESCRIPTION
## Summary

- Forum index `?Comment count=Replies` column showed `0` on miniscope.org even on topics with real replies, because the `ParserAfterParse` annotator in `mediawiki/extensions.platform.php` counted comments by matching the literal string `(UTC)`. Wikis with a non-UTC `$wgLocaltimezone` (signatures end in `(PDT)`/`(PST)`/`(EST)`/etc.) therefore saw `Comment count = 0`, which also suppressed the `Participant count` annotation behind the same gate.
- Reproduced at <https://miniscope.org/wiki/Forum:Home> vs. <https://miniscope.org/wiki/Forum_talk:General/2026-05-14_093445_DAharoni>: the topic has two real signed replies (both `(PDT)`); the forum index reports `0 Replies`.
- Fix: match the full MW English-locale signature timestamp shape `HH:MM, D MONTHNAME YYYY (TZ)` with an open-ended TZ token, instead of the literal `(UTC)`. Anchored on the timestamp pattern so unrelated parenthetical text in the body isn't miscounted as a sig.
- Caveat block in the hook + the runbook's "English-locale signature heuristic" section updated: any timezone now counts; fully-localized non-English month names remain a known undercount.
- Smoke probe extended with a fourth signed line using `(PDT)` so a regression back to the literal-`UTC` match would drop `FORUM_COMMENTS` from 4 → 3 and fail `ci/smoke-test.sh`.

## Deploy note

Existing topic pages need a null-edit (or `php SemanticMediaWiki/maintenance/rebuildData.php -n <forum-talk-ns>` inside the wiki container) for the annotation to backfill — the regex only runs at parse time.

## Test plan

- [ ] `./ci/smoke-test.sh` passes (probe asserts `FORUM_COMMENTS=4`, three UTC + one PDT).
- [ ] On a non-UTC dev wiki, save a topic with one OP + one reply, run `rebuildData.php -n <ns>`, confirm the landing-page `#ask` now shows `Replies=2`.
- [ ] Existing UTC deployments unaffected — the regex matches `(UTC)` too.