### PR TITLE
probe-forum-page: drain refreshLinks queue after annotate jobs

### DIFF
--- a/scripts/probe-forum-page.php
+++ b/scripts/probe-forum-page.php
@@ -90,9 +90,10 @@ class LabkiProbeForumPage extends Maintenance {
         DeferredUpdates::doUpdates();
 
         // Drain the DT annotate jobs queued by PageSaveComplete. Each
-        // job parses Parsoid HTML via DT, caches counts, and runs
-        // RefreshLinksJob inline; RefreshLinksJob then re-renders and
-        // re-stores SMW data with the DT-derived bundle in place.
+        // job parses Parsoid HTML via DT, caches counts, and queues a
+        // RefreshLinksJob (no longer runs it inline as of DiscussionForum
+        // commit a1dc51f — inline collided with the JobRunner's
+        // transaction round and left half-claimed rows on production).
         $jqg = $services->getJobQueueGroup();
         $drained = 0;
         while ( ( $job = $jqg->pop( 'discussionForumAnnotate' ) ) ) {
@@ -100,6 +101,20 @@ class LabkiProbeForumPage extends Maintenance {
             $drained++;
             if ( $drained > 5 ) {
                 $this->fatalError( 'Runaway discussionForumAnnotate job loop (>5 iterations).' );
+            }
+        }
+        DeferredUpdates::doUpdates();
+
+        // Then drain the RefreshLinksJob the annotate job just queued.
+        // It re-parses the page, ParserAfterParse reads the stash, and
+        // SMW's LinksUpdate stores the DT-derived bundle through
+        // OPT_FORCED_UPDATE.
+        $drained = 0;
+        while ( ( $job = $jqg->pop( 'refreshLinks' ) ) ) {
+            $job->run();
+            $drained++;
+            if ( $drained > 5 ) {
+                $this->fatalError( 'Runaway refreshLinks job loop (>5 iterations).' );
             }
         }
         DeferredUpdates::doUpdates();


### PR DESCRIPTION
## Summary

Follow-up to PR #79's DiscussionForum extraction. The extension just landed commit [`a1dc51f`](https://github.com/labki-org/DiscussionForum/commit/a1dc51f) which stops `DTAnnotateJob` from running `RefreshLinksJob` inline — the inline call was colliding with the outer `JobRunner`'s transaction round and leaving half-claimed rows on production miniscope.org's job queue. The annotate job now pushes the RefreshLinksJob to the queue instead.

That makes the smoke probe in this repo undercount: after popping the `discussionForumAnnotate` job and running it, the probe needs to also pop and run the `refreshLinks` job the annotate just queued — otherwise `ParserAfterParse` never re-fires with the populated stash and the assertions on `FORUM_COMMENTS` / `FORUM_PARTICIPANTS` / `FORUM_STARTER` fail.

## Verified locally

After the change:

\`\`\`
DISPLAYTITLE=Hello smoke
DEFAULTSORT=Forum talk:Smoketest/2026-01-01 120000 Bob
FORUM_SUBJECT=Hello smoke
FORUM_STARTER=User:Bob
FORUM_COMMENTS=3
FORUM_PARTICIPANTS=2
FORUM_PARENT=Forum:Smoketest
\`\`\`

## Test plan

- [ ] CI \`smoke-test (dev, enabled)\` passes — exercises the new queued-RefreshLinksJob path through the probe.
- [ ] CI \`smoke-test (prod, enabled)\` passes — same path against the production-style image build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)